### PR TITLE
Builder pattern + better doc comments

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ error_on_line_overflow = true
 error_on_unformatted = true
 format_generated_files = false
 version = "Two"
+format_code_in_doc_comments = true

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,27 @@ pub struct FormatterBuilder {
 }
 
 impl FormatterBuilder {
-    /// Create a [FormatterBuilder] with a custom code block formatter
+    /// Create a [FormatterBuilder] with a custom code block formatter.
+    ///
+    /// The closure used to reformat code blocks takes two arguments;
+    /// the [`info string`] and the complete code snippet
+    ///
+    /// ```rust
+    /// # use markdown_fmt::MarkdownFormatter;
+    /// # use markdown_fmt::FormatterBuilder;
+    /// let builder = FormatterBuilder::with_code_block_formatter(|info_string, code_block| {
+    ///     // Set the code block formatting logic
+    ///     match info_string.to_lowercase().as_str() {
+    ///         "rust" => {
+    ///             // format rust code
+    ///             # code_block
+    ///         }
+    ///         _ => code_block,
+    ///     }
+    /// });
+    /// let formatter = builder.build();
+    /// ```
+    /// [`info string`]: https://spec.commonmark.org/0.31.2/#fenced-code-blocks
     pub fn with_code_block_formatter<'a, F>(formatter: F) -> Self
     where
         F: Fn(&str, String) -> String + 'static,
@@ -16,11 +36,24 @@ impl FormatterBuilder {
         builder
     }
 
-    /// Try to build a [MarkdownFormatter](crate::MarkdownFormatter)
+    /// Build a [MarkdownFormatter](crate::MarkdownFormatter)
+    ///
+    /// ```rust
+    /// # use markdown_fmt::MarkdownFormatter;
+    /// # use markdown_fmt::FormatterBuilder;
+    /// let builder = FormatterBuilder::default();
+    /// let formatter: MarkdownFormatter = builder.build();
+    /// ```
     pub fn build(self) -> crate::MarkdownFormatter {
         crate::MarkdownFormatter::new(self.code_block_formatter)
     }
 
+    /// Configure how code blocks should be reformatted after creating the [FormatterBuilder].
+    ///
+    /// The closure passed to `code_block_formatter` takes two arguments;
+    /// the [`info string`] and the complete code snippet
+    ///
+    /// [`info string`]: https://spec.commonmark.org/0.31.2/#fenced-code-blocks
     pub fn code_block_formatter<'a, F>(&mut self, formatter: F) -> &mut Self
     where
         F: Fn(&str, String) -> String + 'static,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,50 @@
+pub(crate) type CodeBlockFormatter = Box<dyn Fn(&str, String) -> String>;
+
+/// Builder for the [MarkdownFormatter](crate::MarkdownFormatter)
+pub struct FormatterBuilder {
+    code_block_formatter: CodeBlockFormatter,
+}
+
+impl FormatterBuilder {
+    /// Create a [FormatterBuilder] with a custom code block formatter
+    pub fn with_code_block_formatter<'a, F>(formatter: F) -> Self
+    where
+        F: Fn(&str, String) -> String + 'static,
+    {
+        let mut builder = Self::default();
+        builder.code_block_formatter(formatter);
+        builder
+    }
+
+    /// Try to build a [MarkdownFormatter](crate::MarkdownFormatter)
+    pub fn build(self) -> Result<crate::MarkdownFormatter, FormatterBuilder> {
+        Ok(crate::MarkdownFormatter::new(self.code_block_formatter))
+    }
+
+    pub fn code_block_formatter<'a, F>(&mut self, formatter: F) -> &mut Self
+    where
+        F: Fn(&str, String) -> String + 'static,
+    {
+        self.code_block_formatter = Box::new(formatter);
+        self
+    }
+}
+
+impl std::fmt::Debug for FormatterBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FormatterBuilder")
+    }
+}
+
+/// Default formatter which leaves code blocks unformatted
+fn default_code_block_formatter(_info_str: &str, code_block: String) -> String {
+    code_block
+}
+
+impl Default for FormatterBuilder {
+    fn default() -> Self {
+        FormatterBuilder {
+            code_block_formatter: Box::new(default_code_block_formatter),
+        }
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,8 +17,8 @@ impl FormatterBuilder {
     }
 
     /// Try to build a [MarkdownFormatter](crate::MarkdownFormatter)
-    pub fn build(self) -> Result<crate::MarkdownFormatter, FormatterBuilder> {
-        Ok(crate::MarkdownFormatter::new(self.code_block_formatter))
+    pub fn build(self) -> crate::MarkdownFormatter {
+        crate::MarkdownFormatter::new(self.code_block_formatter)
     }
 
     pub fn code_block_formatter<'a, F>(&mut self, formatter: F) -> &mut Self

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,8 +1,8 @@
-use super::MarkdownFormatter;
+use super::formatter::FormatState;
 
 const ATX_HEADER_ESCAPES: [&'static str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
 
-impl<'i, F> MarkdownFormatter<'i, F> {
+impl<'i, F> FormatState<'i, F> {
     pub(super) fn needs_escape(&mut self, input: &str) -> bool {
         if !self.last_was_softbreak {
             // We _should_ only need to escape after a softbreak since the markdown formatter will

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -12,15 +12,36 @@ use crate::links;
 use crate::list::{ListMarker, OrderedListMarker, UnorderedListMarker};
 use crate::table::TableState;
 
+/// Used to format Markdown inputs.
+///
+/// To get a [MarkdownFormatter] use [FormatterBuilder::build]
+///
+/// [FormatterBuilder::build]: crate::FormatterBuilder::build
 pub struct MarkdownFormatter {
     code_block_formatter: CodeBlockFormatter,
 }
 
 impl MarkdownFormatter {
+    /// Format Markdown input
+    ///
+    /// ```rust
+    /// # use markdown_fmt::FormatterBuilder;
+    /// let builder = FormatterBuilder::default();
+    /// let formatter = builder.build();
+    /// let input = "   #  Header! ";
+    /// let rewrite = formatter.format(input).unwrap();
+    /// assert_eq!(rewrite, String::from("# Header!"));
+    /// ```
     pub fn format(self, input: &str) -> std::io::Result<String> {
         FormatState::new(input, self.code_block_formatter).format()
     }
 
+    /// Helper method to easily initiazlie the [MarkdownFormatter].
+    ///
+    /// This is marked as `pub(crate)` because users are expected to use the [FormatterBuilder]
+    /// When creating a [MarkdownFormatter].
+    ///
+    /// [FormatterBuilder]: crate::FormatterBuilder
     pub(crate) fn new(code_block_formatter: CodeBlockFormatter) -> Self {
         Self {
             code_block_formatter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,51 @@ mod utils;
 
 pub use builder::FormatterBuilder;
 pub use formatter::MarkdownFormatter;
+
+/// Reformat a markdown snippet with all the default settings.
+pub fn rewrite_markdown(input: &str) -> Result<String, std::io::Error> {
+    rewrite_markdown_with_builder(input, FormatterBuilder::default())
+}
+
+/// Reformat a markdown snippet with user specified settings
+pub fn rewrite_markdown_with_builder(
+    input: &str,
+    builder: FormatterBuilder,
+) -> Result<String, std::io::Error> {
+    let formatter = builder.build();
+    formatter.format(input)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn reformat() {
+        let input = r##"#  Hello World!
+1.  Hey [ there! ]
+2.  what's going on?
+
+<p> and a little bit of HTML </p>
+
+```rust
+fn main() {}
+```
+[
+    there!
+    ]: htts://example.com "Yoooo"
+"##;
+        let expected = r##"# Hello World!
+1. Hey [ there! ]
+2. what's going on?
+
+<p> and a little bit of HTML </p>
+
+```rust
+fn main() {}
+```
+[ there! ]: htts://example.com "Yoooo""##;
+        let rewrite = rewrite_markdown(input).unwrap();
+        assert_eq!(rewrite, expected)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod builder;
 mod escape;
 mod formatter;
 mod links;
@@ -5,4 +6,5 @@ mod list;
 mod table;
 mod utils;
 
+pub use builder::FormatterBuilder;
 pub use formatter::MarkdownFormatter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,54 @@ pub use builder::FormatterBuilder;
 pub use formatter::MarkdownFormatter;
 
 /// Reformat a markdown snippet with all the default settings.
+///
+/// ```rust
+/// # use markdown_fmt::rewrite_markdown;
+/// let markdown = r##"  #   Learn Rust Checklist!
+/// 1. Read [The Book]
+///  2.  Watch tutorials
+///   3.   Write some code!
+///
+/// [The Book]: https://doc.rust-lang.org/book/
+/// "##;
+///
+/// let formatted_markdown = r##"# Learn Rust Checklist!
+/// 1. Read [The Book]
+/// 2. Watch tutorials
+/// 3. Write some code!
+///
+/// [The Book]: https://doc.rust-lang.org/book/"##;
+///
+/// let output = rewrite_markdown(markdown).unwrap();
+/// assert_eq!(output, formatted_markdown);
+/// ```
 pub fn rewrite_markdown(input: &str) -> Result<String, std::io::Error> {
     rewrite_markdown_with_builder(input, FormatterBuilder::default())
 }
 
 /// Reformat a markdown snippet with user specified settings
+///
+/// ```rust
+/// # use markdown_fmt::{rewrite_markdown_with_builder, FormatterBuilder};
+/// let markdown = r##"  #   Learn Rust Checklist!
+/// 1. Read [The Book]
+///  2.  Watch tutorials
+///   3.   Write some code!
+///
+/// [The Book]: https://doc.rust-lang.org/book/
+/// "##;
+///
+/// let formatted_markdown = r##"# Learn Rust Checklist!
+/// 1. Read [The Book]
+/// 2. Watch tutorials
+/// 3. Write some code!
+///
+/// [The Book]: https://doc.rust-lang.org/book/"##;
+///
+/// let builder = FormatterBuilder::default();
+/// let output = rewrite_markdown_with_builder(markdown, builder).unwrap();
+/// assert_eq!(output, formatted_markdown);
+/// ```
 pub fn rewrite_markdown_with_builder(
     input: &str,
     builder: FormatterBuilder,

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,8 +1,8 @@
-use super::MarkdownFormatter;
+use super::formatter::FormatState;
 use pulldown_cmark::escape::StrWrite;
 use std::borrow::Cow;
 
-impl<'i, F> MarkdownFormatter<'i, F> {
+impl<'i, F> FormatState<'i, F> {
     pub(super) fn write_inline_link<S: AsRef<str>>(
         &mut self,
         url: &str,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,13 +1,10 @@
 /// Collection of common functions / macros used for generating tests
-use markdown_fmt::FormatterBuilder;
 
 pub fn check_formatted_markdown<'a, 'o>(
     input: &'a str,
     expected_output: &'o str,
 ) -> std::borrow::Cow<'a, str> {
-    let builder = FormatterBuilder::with_code_block_formatter(|_, code_block| code_block);
-    let formatter = builder.build().unwrap();
-    let formatted = formatter.format(input).expect("formatting won't fail");
+    let formatted = markdown_fmt::rewrite_markdown(input).expect("formatting won't fail");
     assert_eq!(formatted, expected_output);
     formatted.into()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,11 +1,13 @@
 /// Collection of common functions / macros used for generating tests
+use markdown_fmt::FormatterBuilder;
 
 pub fn check_formatted_markdown<'a, 'o>(
     input: &'a str,
     expected_output: &'o str,
 ) -> std::borrow::Cow<'a, str> {
-    let formatter = markdown_fmt::MarkdownFormatter::new(input, |_, code_block| code_block);
-    let formatted = formatter.format().expect("formatting wont fail");
+    let builder = FormatterBuilder::with_code_block_formatter(|_, code_block| code_block);
+    let formatter = builder.build().unwrap();
+    let formatted = formatter.format(input).expect("formatting won't fail");
     assert_eq!(formatted, expected_output);
     formatted.into()
 }


### PR DESCRIPTION
I think using the builder pattern would be the most flexible design once I get around to adding configurations, that way new configurations could be added in a backwards compatible way.