### PR TITLE
Lay the groundwork to consume compiler internals and parse crates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
       run: cargo +nightly fmt --check
 
     - name: Run tests
-      run: cargo +nightly test --features gen-tests
+      run: cargo test --features gen-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,8 @@ jobs:
       run: cargo +nightly fmt --check
 
     - name: Run tests
-      run: cargo test --features gen-tests
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build --locked
+        cargo test --features gen-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,7 @@ jobs:
 
     - name: Install Nightly Rust Toolchain
       run: |
-        rustup install --no-self-update --profile minimal nightly
-        rustup component add --toolchain nightly rustfmt
+        rustup install --no-self-update --profile default nightly
 
     - name: Format Checks
       run: cargo +nightly fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ gen-tests = []
 [build-dependencies]
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
+
+# Rustc dependencies are loaded from the sysroot, Cargo doesn't know about them.
+
+[package.metadata.rust-analyzer]
+# This package uses #[feature(rustc_private)]
+rustc_private = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-03-05"
+channel = "nightly-2024-02-29"
 components = ["llvm-tools", "rustc-dev"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-03-05"
+components = ["llvm-tools", "rustc-dev"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,28 @@
+#![feature(rustc_private)]
+
+// N.B. these crates are loaded from the sysroot, so they need extern crate.
+extern crate rustc_ast;
+extern crate rustc_ast_pretty;
+extern crate rustc_builtin_macros;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_expand;
+extern crate rustc_parse;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate thin_vec;
+
+// Necessary to pull in object code as the rest of the rustc crates are shipped only as rmeta
+// files.
+#[allow(unused_extern_crates)]
+extern crate rustc_driver;
+
 mod builder;
 mod escape;
 mod formatter;
 mod links;
 mod list;
+pub mod rust_crate;
 mod table;
 mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,16 @@
+#![feature(rustc_private)]
+
+extern crate rustc_span;
+use rustc_span::edition::Edition;
+
+use markdown_fmt::rust_crate::parse_crate::rewrite_doc_comments_in_crate;
+
+fn main() -> Result<(), std::io::Error> {
+    let path = std::path::PathBuf::from("src/lib.rs");
+    rustc_span::create_session_if_not_set_then(Edition::Edition2021, |_| {
+        if let Ok(Some(result)) = rewrite_doc_comments_in_crate(&path) {
+            return std::fs::write(path, result);
+        }
+        Ok(())
+    })
+}

--- a/src/rust_crate.rs
+++ b/src/rust_crate.rs
@@ -1,0 +1,1 @@
+pub mod parse_crate;

--- a/src/rust_crate/parse_crate.rs
+++ b/src/rust_crate/parse_crate.rs
@@ -1,0 +1,108 @@
+use rustc_ast::ast::Crate;
+use rustc_ast::HasAttrs;
+use rustc_ast::Item;
+use rustc_ast::{AttrKind, AttrStyle, Attribute};
+use rustc_parse::new_parser_from_file;
+use rustc_session::parse::ParseSess;
+use rustc_span::{BytePos, Pos, Span};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::Path;
+use std::rc::Rc;
+
+pub fn rewrite_doc_comments_in_crate<P: AsRef<Path>>(
+    file: P,
+) -> Result<Option<String>, std::io::Error> {
+    let fatal_message = String::from("Something went wrong 🥲");
+    let session = ParseSess::with_silent_emitter(fatal_message);
+    let input = std::fs::read_to_string(&file)?;
+
+    match catch_unwind(AssertUnwindSafe(|| {
+        new_parser_from_file(&session, file.as_ref(), None)
+    })) {
+        Ok(mut p) => match p.parse_crate_mod() {
+            Ok(c) => Ok(Some(format_crate(&c, &input).to_string())),
+            Err(e) => {
+                e.emit();
+                Ok(None)
+            }
+        },
+        Err(e) => {
+            println!("{e:?}");
+            Ok(None)
+        }
+    }
+}
+
+struct FormatContext<'a> {
+    last_position: RefCell<BytePos>,
+    buffer: Rc<RefCell<String>>,
+    input: &'a str,
+}
+
+impl<'a> FormatContext<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            last_position: RefCell::new(BytePos::from_usize(0)),
+            buffer: Rc::new(RefCell::new(String::new())),
+            input,
+        }
+    }
+
+    fn lo(&self) -> BytePos {
+        BytePos::from_usize(self.last_position.borrow().to_usize())
+    }
+
+    fn write_end(self, krate: &Crate) -> String {
+        let span = krate.spans.inner_span.with_lo(self.lo());
+        self.write_value(span, None);
+        self.buffer.borrow_mut().push('\n');
+        self.to_buffer()
+    }
+
+    fn write_value(&self, span: Span, rewrite: Option<Cow<'a, str>>) {
+        if let Some(value) = rewrite {
+            self.buffer.as_ref().borrow_mut().push_str(&value)
+        } else {
+            let lo = self.last_position.borrow().to_usize();
+            let hi = span.hi().to_usize();
+            self.buffer
+                .as_ref()
+                .borrow_mut()
+                .push_str(&self.input[lo..hi])
+        }
+        *self.last_position.borrow_mut() = span.hi()
+    }
+
+    fn to_buffer(self) -> String {
+        self.buffer.take()
+    }
+}
+
+fn format_crate<'a>(krate: &Crate, input: &'a str) -> Cow<'a, str> {
+    if input.trim().is_empty() {
+        return Cow::Borrowed(input);
+    }
+
+    let context = FormatContext::new(input);
+    format_attrs(krate.attrs(), AttrStyle::Inner, &context);
+    format_items(&krate.items, &context);
+    Cow::Owned(context.write_end(krate))
+}
+
+fn format_attrs(attrs: &[Attribute], style: AttrStyle, context: &FormatContext) {
+    for attr in attrs {
+        if attr.style != style {
+            context.write_value(attr.span, None);
+            continue;
+        }
+    }
+}
+
+fn format_items(items: &[rustc_ast::ptr::P<Item>], context: &FormatContext) {
+    for item in items {
+        format_attrs(item.attrs(), AttrStyle::Outer, context);
+        context.write_value(item.span, None)
+    }
+}


### PR DESCRIPTION
I also set up a very minimal binary to rewrite crates. So far all I'm doing is spitting back out the spans from each AST node, but at least that's a step in the right direction.

One thing to note; since I'm now consuming types from the compiler I added a rust-toolchain file to specify the nightly compiler version I need in order to compile the project. I'm hopeful that since I don't foresee the need to consume many types upgrading to newer nightly version won't be difficult.