### PR TITLE
Fix typo

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -906,8 +906,8 @@ where
                 //     final list item, you can insert a blank HTML comment
                 if let Some(Event::Start(Tag::CodeBlock(CodeBlockKind::Indented))) = self.peek() {
                     self.write_newlines(1)?;
-                    write!(self, "<!-- Dont absorb code block into list -->\n")?;
-                    write!(self, "<!-- Consider a feenced code block instead -->")?;
+                    write!(self, "<!-- Don't absorb code block into list -->\n")?;
+                    write!(self, "<!-- Consider a fenced code block instead -->")?;
                 };
             }
             Tag::Item => {

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -2155,7 +2155,7 @@
   },
   {
     "markdown": " -    one\n\n     two\n",
-    "formattedMarkdown": "- one\n<!-- Dont absorb code block into list -->\n<!-- Consider a feenced code block instead -->\n\n     two",
+    "formattedMarkdown": "- one\n<!-- Don't absorb code block into list -->\n<!-- Consider a fenced code block instead -->\n\n     two",
     "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
     "example": 257,
     "start_line": 4220,
@@ -2632,7 +2632,7 @@
   },
   {
     "markdown": "1. a\n\n  2. b\n\n    3. c\n",
-    "formattedMarkdown": "1. a\n\n2. b\n<!-- Dont absorb code block into list -->\n<!-- Consider a feenced code block instead -->\n\n    3. c",
+    "formattedMarkdown": "1. a\n\n2. b\n<!-- Don't absorb code block into list -->\n<!-- Consider a fenced code block instead -->\n\n    3. c",
     "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n</ol>\n<pre><code>3. c\n</code></pre>\n",
     "example": 313,
     "start_line": 5556,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -2218,7 +2218,7 @@
   },
   {
     "markdown": " -    one\n\n     two\n",
-    "formattedMarkdown": "- one\n<!-- Dont absorb code block into list -->\n<!-- Consider a feenced code block instead -->\n\n     two",
+    "formattedMarkdown": "- one\n<!-- Don't absorb code block into list -->\n<!-- Consider a fenced code block instead -->\n\n     two",
     "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
     "example": 235,
     "start_line": 4081,
@@ -2750,7 +2750,7 @@
   },
   {
     "markdown": "1. a\n\n  2. b\n\n    3. c\n",
-    "formattedMarkdown": "1. a\n\n2. b\n<!-- Dont absorb code block into list -->\n<!-- Consider a feenced code block instead -->\n\n    3. c",
+    "formattedMarkdown": "1. a\n\n2. b\n<!-- Don't absorb code block into list -->\n<!-- Consider a fenced code block instead -->\n\n    3. c",
     "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n</ol>\n<pre><code>3. c\n</code></pre>\n",
     "example": 293,
     "start_line": 5475,


### PR DESCRIPTION
These typos were originally caught in rust-lang/rustfmt 5909. Now that I'm making this its own crate I'm getting around to fixing these.