### PR TITLE
Gate dependencies / binary behind features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,22 @@ include = ["/src/**/*", "/LICENSE", "/README.md", "/CHANGELOG.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "markdown-fmt"
+required-features = ["build-binary"]
+
 [dependencies]
 itertools = "0.10"
 pulldown-cmark = { version = "0.9.3", default-features = false }
 unicode-width = "0.1"
 unicode-segmentation = "1.9"
-clap = { version = "4.5.2", features = ["derive"] }
-anyhow = "1.0.80"
+clap = { version = "4.5.2", features = ["derive"], optional = true }
+anyhow = { version = "1.0.80", optional = true }
 
 [features]
-gen-tests = []
+gen-tests = ["dep:serde", "dep:serde_json"]
+build-binary = ["dep:clap", "dep:anyhow"]
 
 [build-dependencies]
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.160", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
-    /// Input file. Markdown (.md) or Rust (.rs)
+    /// Input Markdown (.md) file.
     input: PathBuf,
     /// Whether to emit output to stdout. Otherwise the content of the
     /// original file will be overwritten


### PR DESCRIPTION
A very minor change to shorten compile times. Now serde and serde_json are only compiled when building our tests and clap and anyhow are only compiled when building our binary.

The `gen-tests` was an existing feature, but now it's dependencies are optional. A new feature named `build-binary` is used to contorl if a binary is built.