### PR TITLE
remove space between blockquotes and improve empty blockquote formatting

### DIFF
--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -2082,7 +2082,8 @@ fn markdown_block_quotes_240() {
 #[test]
 fn markdown_block_quotes_241() {
     // https://spec.commonmark.org/0.30/#example-241
-    test_identical_markdown_events!(">\n> foo\n>  ",r##"> foo
+    test_identical_markdown_events!(">\n> foo\n>  ",r##">
+> foo
 >"##);
 }
 
@@ -2152,8 +2153,8 @@ baz"##);
 fn markdown_block_quotes_250() {
     // https://spec.commonmark.org/0.30/#example-250
     test_identical_markdown_events!(r##"> > > foo
-bar"##,r##"> > > foo
-> > > bar"##);
+bar"##,r##">>> foo
+>>> bar"##);
 }
 
 #[test]
@@ -2161,9 +2162,9 @@ fn markdown_block_quotes_251() {
     // https://spec.commonmark.org/0.30/#example-251
     test_identical_markdown_events!(r##">>> foo
 > bar
->>baz"##,r##"> > > foo
-> > > bar
-> > > baz"##);
+>>baz"##,r##">>> foo
+>>> bar
+>>> baz"##);
 }
 
 #[test]
@@ -2248,9 +2249,9 @@ fn markdown_list_items_259() {
     // https://spec.commonmark.org/0.30/#example-259
     test_identical_markdown_events!(r##"   > > 1.  one
 >>
->>     two"##,r##"> > 1. one
-> >
-> >    two"##);
+>>     two"##,r##">> 1. one
+>>
+>>    two"##);
 }
 
 #[test]
@@ -2258,9 +2259,9 @@ fn markdown_list_items_260() {
     // https://spec.commonmark.org/0.30/#example-260
     test_identical_markdown_events!(r##">>- one
 >>
-  >  > two"##,r##"> > - one
-> >
-> > two"##);
+  >  > two"##,r##">> - one
+>>
+>> two"##);
 }
 
 #[test]

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1943,7 +1943,8 @@ fn gfm_markdown_block_quotes_218() {
 #[test]
 fn gfm_markdown_block_quotes_219() {
     // https://github.github.com/gfm/#example-219
-    test_identical_markdown_events!(">\n> foo\n>  ",r##"> foo
+    test_identical_markdown_events!(">\n> foo\n>  ",r##">
+> foo
 >"##);
 }
 
@@ -2013,8 +2014,8 @@ baz"##);
 fn gfm_markdown_block_quotes_228() {
     // https://github.github.com/gfm/#example-228
     test_identical_markdown_events!(r##"> > > foo
-bar"##,r##"> > > foo
-> > > bar"##);
+bar"##,r##">>> foo
+>>> bar"##);
 }
 
 #[test]
@@ -2022,9 +2023,9 @@ fn gfm_markdown_block_quotes_229() {
     // https://github.github.com/gfm/#example-229
     test_identical_markdown_events!(r##">>> foo
 > bar
->>baz"##,r##"> > > foo
-> > > bar
-> > > baz"##);
+>>baz"##,r##">>> foo
+>>> bar
+>>> baz"##);
 }
 
 #[test]
@@ -2109,9 +2110,9 @@ fn gfm_markdown_list_items_237() {
     // https://github.github.com/gfm/#example-237
     test_identical_markdown_events!(r##"   > > 1.  one
 >>
->>     two"##,r##"> > 1. one
-> >
-> >    two"##);
+>>     two"##,r##">> 1. one
+>>
+>>    two"##);
 }
 
 #[test]
@@ -2119,9 +2120,9 @@ fn gfm_markdown_list_items_238() {
     // https://github.github.com/gfm/#example-238
     test_identical_markdown_events!(r##">>- one
 >>
-  >  > two"##,r##"> > - one
-> >
-> > two"##);
+  >  > two"##,r##">> - one
+>>
+>> two"##);
 }
 
 #[test]

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -2020,7 +2020,7 @@
   },
   {
     "markdown": ">\n> foo\n>  \n",
-    "formattedMarkdown": "> foo\n>",
+    "formattedMarkdown": ">\n> foo\n>",
     "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
     "example": 241,
     "start_line": 3915,
@@ -2094,7 +2094,7 @@
   },
   {
     "markdown": "> > > foo\nbar\n",
-    "formattedMarkdown": "> > > foo\n> > > bar",
+    "formattedMarkdown": ">>> foo\n>>> bar",
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
     "example": 250,
     "start_line": 4048,
@@ -2103,7 +2103,7 @@
   },
   {
     "markdown": ">>> foo\n> bar\n>>baz\n",
-    "formattedMarkdown": "> > > foo\n> > > bar\n> > > baz",
+    "formattedMarkdown": ">>> foo\n>>> bar\n>>> baz",
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
     "example": 251,
     "start_line": 4063,
@@ -2174,7 +2174,7 @@
   },
   {
     "markdown": "   > > 1.  one\n>>\n>>     two\n",
-    "formattedMarkdown": "> > 1. one\n> >\n> >    two",
+    "formattedMarkdown": ">> 1. one\n>>\n>>    two",
     "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
     "example": 259,
     "start_line": 4255,
@@ -2183,7 +2183,7 @@
   },
   {
     "markdown": ">>- one\n>>\n  >  > two\n",
-    "formattedMarkdown": "> > - one\n> >\n> > two",
+    "formattedMarkdown": ">> - one\n>>\n>> two",
     "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
     "example": 260,
     "start_line": 4282,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -2067,7 +2067,7 @@
   },
   {
     "markdown": ">\n> foo\n>  \n",
-    "formattedMarkdown": "> foo\n>",
+    "formattedMarkdown": ">\n> foo\n>",
     "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
     "example": 219,
     "start_line": 3776,
@@ -2150,7 +2150,7 @@
   },
   {
     "markdown": "> > > foo\nbar\n",
-    "formattedMarkdown": "> > > foo\n> > > bar",
+    "formattedMarkdown": ">>> foo\n>>> bar",
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
     "example": 228,
     "start_line": 3909,
@@ -2160,7 +2160,7 @@
   },
   {
     "markdown": ">>> foo\n> bar\n>>baz\n",
-    "formattedMarkdown": "> > > foo\n> > > bar\n> > > baz",
+    "formattedMarkdown": ">>> foo\n>>> bar\n>>> baz",
     "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
     "example": 229,
     "start_line": 3924,
@@ -2239,7 +2239,7 @@
   },
   {
     "markdown": "   > > 1.  one\n>>\n>>     two\n",
-    "formattedMarkdown": "> > 1. one\n> >\n> >    two",
+    "formattedMarkdown": ">> 1. one\n>>\n>>    two",
     "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
     "example": 237,
     "start_line": 4116,
@@ -2249,7 +2249,7 @@
   },
   {
     "markdown": ">>- one\n>>\n  >  > two\n",
-    "formattedMarkdown": "> > - one\n> >\n> > two",
+    "formattedMarkdown": ">> - one\n>>\n>> two",
     "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
     "example": 238,
     "start_line": 4143,


### PR DESCRIPTION
Before all blockquotes would add "> " to the internal indentation. Now there's much better support for turning "> > >" into ">>>".

Additionally, there were some edge cases around empty block quotes that weren't handled properly. Now markdown-fmt does a much better job of retaining them.