### PR TITLE
Better handling of empty, fenced code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-target/
+/target

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -2050,7 +2050,6 @@ fn markdown_block_quotes_237() {
     test_identical_markdown_events!(r##"> ```
 foo
 ```"##,r##"> ```
->
 > ```
 foo
 ```

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1911,7 +1911,6 @@ fn gfm_markdown_block_quotes_215() {
     test_identical_markdown_events!(r##"> ```
 foo
 ```"##,r##"> ```
->
 > ```
 foo
 ```

--- a/tests/source/empty_code_blocks.md
+++ b/tests/source/empty_code_blocks.md
@@ -1,0 +1,77 @@
+```no_indent
+```
+
+```no_indent_with_newlines
+
+
+```
+
+1. ```same_line_list
+   ```
+
+2. ```same_line_list_with_newlines
+
+
+   ```
+
+3.
+   ```next_line_of_list
+   ```
+
+4.
+   ```next_line_of_list_with_newlines
+
+
+   ```
+
+> ```quoted
+> ```
+
+> ```quoted_with_newlines
+>
+>
+> ```
+
+> * ```quoted_same_line_list
+>   ```
+
+> * ```quoted_same_line_list_with_newlines
+>
+>
+>   ```
+
+> -
+>   ```quoted_next_line_of_list
+>   ```
+
+> -
+>   ```quoted_next_line_of_list_with_newlines
+>
+>
+>   ```
+
+>> *
+>>   +
+>>     0001. > 0001) ```super_nested_same_line_list
+>>           >       ```
+
+>> *
+>>   +
+>>     0002. > 0002) ```super_nested_same_line_list_with_newlines
+>>           >
+>>           >
+>>           >       ```
+
+>> *
+>>   +
+>>     0003. > 0003)
+>>           >       ```super_nested_next_line_list
+>>           >       ```
+
+>> *
+>>   +
+>>     0004. > 0004)
+>>           >       ```super_nested_next_line_list_with_newlines
+>>           >
+>>           >
+>>           >       ```

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -1985,7 +1985,7 @@
   },
   {
     "markdown": "> ```\nfoo\n```\n",
-    "formattedMarkdown": "> ```\n>\n> ```\nfoo\n```\n```",
+    "formattedMarkdown": "> ```\n> ```\nfoo\n```\n```",
     "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
     "example": 237,
     "start_line": 3855,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -2028,7 +2028,7 @@
   },
   {
     "markdown": "> ```\nfoo\n```\n",
-    "formattedMarkdown": "> ```\n>\n> ```\nfoo\n```\n```",
+    "formattedMarkdown": "> ```\n> ```\nfoo\n```\n```",
     "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
     "example": 215,
     "start_line": 3716,

--- a/tests/target/empty_code_blocks.md
+++ b/tests/target/empty_code_blocks.md
@@ -1,0 +1,61 @@
+```no_indent
+```
+
+```no_indent_with_newlines
+```
+
+1. ```same_line_list
+   ```
+
+2. ```same_line_list_with_newlines
+   ```
+
+3.
+   ```next_line_of_list
+   ```
+
+4.
+   ```next_line_of_list_with_newlines
+   ```
+
+> ```quoted
+> ```
+
+> ```quoted_with_newlines
+> ```
+
+> * ```quoted_same_line_list
+>   ```
+
+> * ```quoted_same_line_list_with_newlines
+>   ```
+
+> -
+>   ```quoted_next_line_of_list
+>   ```
+
+> -
+>   ```quoted_next_line_of_list_with_newlines
+>   ```
+
+>> *
+>>   +
+>>     0001. > 0001) ```super_nested_same_line_list
+>>           >       ```
+
+>> *
+>>   +
+>>     0002. > 0002) ```super_nested_same_line_list_with_newlines
+>>           >       ```
+
+>> *
+>>   +
+>>     0003. > 0003)
+>>           >       ```super_nested_next_line_list
+>>           >       ```
+
+>> *
+>>   +
+>>     0004. > 0004)
+>>           >       ```super_nested_next_line_list_with_newlines
+>>           >       ```


### PR DESCRIPTION
empty code blocks are collapsed, and they are now properly indented given the nested context that they might be written in.