### PR TITLE
use `std::fmt::Write` instead of `pulldown_cmark::escape::StrWrite`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! let output = rewrite_markdown(markdown)?;
 //! # assert_eq!(output, formatted);
-//! # Ok::<(), std::io::Error>(())
+//! # Ok::<(), std::fmt::Error>(())
 //! ```
 //!
 //! # Using the [Builder](builder::FormatterBuilder)
@@ -62,7 +62,7 @@
 //!
 //! let output = rewrite_markdown_with_builder(markdown, builder)?;
 //! # assert_eq!(output, formatted);
-//! # Ok::<(), std::io::Error>(())
+//! # Ok::<(), std::fmt::Error>(())
 //! ````
 
 mod builder;
@@ -99,7 +99,7 @@ pub use formatter::MarkdownFormatter;
 /// let output = rewrite_markdown(markdown).unwrap();
 /// assert_eq!(output, formatted_markdown);
 /// ```
-pub fn rewrite_markdown(input: &str) -> Result<String, std::io::Error> {
+pub fn rewrite_markdown(input: &str) -> Result<String, std::fmt::Error> {
     rewrite_markdown_with_builder(input, FormatterBuilder::default())
 }
 
@@ -130,7 +130,7 @@ pub fn rewrite_markdown(input: &str) -> Result<String, std::io::Error> {
 pub fn rewrite_markdown_with_builder(
     input: &str,
     builder: FormatterBuilder,
-) -> Result<String, std::io::Error> {
+) -> Result<String, std::fmt::Error> {
     let formatter = builder.build();
     formatter.format(input)
 }

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,13 +1,13 @@
 use super::formatter::FormatState;
-use pulldown_cmark::escape::StrWrite;
 use std::borrow::Cow;
+use std::fmt::Write;
 
 impl<'i, F> FormatState<'i, F> {
     pub(super) fn write_inline_link<S: AsRef<str>>(
         &mut self,
         url: &str,
         title: Option<(S, char)>,
-    ) -> std::io::Result<()> {
+    ) -> std::fmt::Result {
         let url = format_link_url(url, false);
         match title {
             Some((title, ')')) => write!(self, r#"]({url} ({}))"#, title.as_ref())?,


### PR DESCRIPTION
I'm not sure why it didn't occur to me sooner, but `std::fmt::Write` has a `write_str` method, and that's essentially why I was using `pulldown_cmark::escape::StrWrite`. That and I initially based the structure of my markdown formatting on
`pulldown_cmark::html::write_html`, which internally uses `pulldown_cmark::escape::StrWrite`.

The main difference is that `write_html` returns `std::io::Result<()>`, and the `std::io::Write` trait doesn't have a `write_str` method so `pulldown_cmark::escape::StrWrite` essentially provides a `write!` compatable API that resembles the `std::io::Write` trait.

based on the [`write!`] docs it seems that there isn't much of a difference between implementing `std::io::Write` vs `std::fmt::Write` so for my use case I think implementing `std::fmt::Write` is the right call, and it reduces my reliance on `pulldown_cmark::escape::StrWrite`.

[`write!`]: https://doc.rust-lang.org/std/macro.write.html