### PR TITLE
make FormatState generic over the (Event, Range) iterator

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -2,7 +2,10 @@ use super::formatter::FormatState;
 
 const ATX_HEADER_ESCAPES: [&str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
 
-impl<'i, F> FormatState<'i, F> {
+impl<'i, F, I> FormatState<'i, F, I>
+where
+    I: Iterator,
+{
     pub(super) fn needs_escape(&mut self, input: &str) -> bool {
         if !self.last_was_softbreak {
             // We _should_ only need to escape after a softbreak since the markdown formatter will

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,8 +1,12 @@
 use super::formatter::FormatState;
+use pulldown_cmark::Event;
 use std::borrow::Cow;
 use std::fmt::Write;
 
-impl<'i, F> FormatState<'i, F> {
+impl<'i, F, I> FormatState<'i, F, I>
+where
+    I: Iterator<Item = (Event<'i>, std::ops::Range<usize>)>,
+{
     pub(super) fn write_inline_link<S: AsRef<str>>(
         &mut self,
         url: &str,


### PR DESCRIPTION
This is an internal change that should not impact formatting. To add support for wrapping "tight" markdown lists I plan on adding an adapter that will modify the event iterator. Making the iterator generic will simplify that future work.