### PR TITLE
Paragraph formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,7 +112,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -124,16 +140,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.6",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "itertools"
@@ -157,6 +264,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +293,7 @@ dependencies = [
  "clap",
  "itertools",
  "pulldown-cmark",
+ "rust_search",
  "serde",
  "serde_json",
  "tracing",
@@ -201,6 +325,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -236,7 +370,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -248,6 +382,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -295,10 +440,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rust_search"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27d7be20245d289c9dde663f06521de08663d73cbaefc45785aa65d02022378"
+dependencies = [
+ "dirs",
+ "ignore",
+ "num_cpus",
+ "regex",
+ "strsim 0.10.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -348,6 +515,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
@@ -361,6 +534,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -468,6 +661,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +691,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "rust_search",
  "serde",
  "serde_json",
+ "textwrap",
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
@@ -514,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +541,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -629,6 +647,12 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ build-binary = ["dep:clap", "dep:anyhow", "dep:tracing-subscriber"]
 [build-dependencies]
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+
+[dev-dependencies]
+rust_search = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.5.2", features = ["derive"], optional = true }
 anyhow = { version = "1.0.80", optional = true }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }
+textwrap = "0.16.1"
 
 [features]
 gen-tests = ["dep:serde", "dep:serde_json"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -64,6 +64,14 @@ impl FormatterBuilder {
         self.code_block_formatter = Box::new(formatter);
         self
     }
+
+    /// Configure the max with when rewriting paragraphs.
+    ///
+    /// When set to [None], the deafault, paragraph width is left unchanged.
+    pub fn max_width(&mut self, max_width: Option<usize>) -> &mut Self {
+        self.config.set_max_width(max_width);
+        self
+    }
 }
 
 impl std::fmt::Debug for FormatterBuilder {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -72,6 +72,13 @@ impl FormatterBuilder {
         self.config.set_max_width(max_width);
         self
     }
+
+    /// Internal setter for Config. Used for testing
+    #[cfg(test)]
+    pub(crate) fn config(&mut self, config: Config) -> &mut Self {
+        self.config = config;
+        self
+    }
 }
 
 impl std::fmt::Debug for FormatterBuilder {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,3 +2,13 @@
 pub(crate) struct Config {
     max_width: Option<usize>,
 }
+
+impl Config {
+    pub(crate) fn max_width(&self) -> Option<usize> {
+        self.max_width
+    }
+
+    pub(crate) fn set_max_width(&mut self, value: Option<usize>) {
+        self.max_width = value;
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,2 +1,4 @@
 #[derive(Debug, Default)]
-pub(crate) struct Config {}
+pub(crate) struct Config {
+    max_width: Option<usize>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,4 +11,16 @@ impl Config {
     pub(crate) fn set_max_width(&mut self, value: Option<usize>) {
         self.max_width = value;
     }
+
+    /// Internal setter for config options. Used for testing
+    #[cfg(test)]
+    pub(crate) fn set(&mut self, field: &str, value: &str) {
+        match field {
+            "max_width" => {
+                let value = value.parse::<usize>().unwrap();
+                self.max_width = Some(value)
+            }
+            _ => panic!("unknown configuration {field}"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ mod formatter;
 mod links;
 mod list;
 mod table;
+#[cfg(test)]
+mod test;
 mod utils;
 
 pub use builder::FormatterBuilder;
@@ -134,39 +136,4 @@ pub fn rewrite_markdown_with_builder(
 ) -> Result<String, std::fmt::Error> {
     let formatter = builder.build();
     formatter.format(input)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn reformat() {
-        let input = r##"#  Hello World!
-1.  Hey [ there! ]
-2.  what's going on?
-
-<p> and a little bit of HTML </p>
-
-```rust
-fn main() {}
-```
-[
-    there!
-    ]: htts://example.com "Yoooo"
-"##;
-        let expected = r##"# Hello World!
-1. Hey [there!]
-2. what's going on?
-
-<p> and a little bit of HTML </p>
-
-```rust
-fn main() {}
-```
-[there!]: htts://example.com "Yoooo"
-"##;
-        let rewrite = rewrite_markdown(input).unwrap();
-        assert_eq!(rewrite, expected)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ mod escape;
 mod formatter;
 mod links;
 mod list;
+mod paragraph;
 mod table;
 #[cfg(test)]
 mod test;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use clap::Parser;
-use markdown_fmt::rewrite_markdown;
+use markdown_fmt::{rewrite_markdown_with_builder, FormatterBuilder};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,6 +16,9 @@ struct Cli {
     /// original file will be overwritten
     #[arg(long, default_value_t = false)]
     stdout: bool,
+    /// The max width to use when reformatting paragraphs.
+    #[arg(short, long)]
+    max_width: Option<usize>,
 }
 
 fn output_result(input: &Path, result: &str, stdout: bool) -> Result<(), anyhow::Error> {
@@ -38,7 +41,9 @@ fn main() -> Result<(), anyhow::Error> {
     match cli.input.extension().and_then(OsStr::to_str) {
         Some("md") => {
             let input = fs::read_to_string(&cli.input)?;
-            let result = rewrite_markdown(&input)?;
+            let mut builder = FormatterBuilder::default();
+            builder.max_width(cli.max_width);
+            let result = rewrite_markdown_with_builder(&input, builder)?;
             output_result(&cli.input, &result, cli.stdout)
         }
         _ => Err(anyhow::anyhow!(

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -1,0 +1,85 @@
+use std::fmt::Write;
+use textwrap::Options as TextWrapOptions;
+
+const MARKDOWN_HARD_BREAK: &str = "  \n";
+
+/// A buffer where we write text
+pub(super) struct Paragraph {
+    buffer: String,
+    max_width: Option<usize>,
+}
+
+impl Write for Paragraph {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        let is_hard_break = |s: &str| -> bool {
+            // Hard breaks can have any amount of leading whitesace followed by a newline
+            s.strip_prefix("  ")
+                .is_some_and(|maybe_hard_break| maybe_hard_break.trim_start_matches(' ').eq("\n"))
+        };
+
+        if self.max_width.is_some() && is_hard_break(s) {
+            self.buffer.push_str(MARKDOWN_HARD_BREAK);
+            return Ok(());
+        }
+
+        if self.max_width.is_some() && s.trim().is_empty() {
+            // If the user configured the max_width then push a space so we can reflow text
+            self.buffer.push(' ');
+        } else {
+            self.buffer.push_str(s);
+        }
+
+        Ok(())
+    }
+}
+
+impl Paragraph {
+    pub(super) fn new(max_width: Option<usize>, capacity: usize) -> Self {
+        Self {
+            max_width,
+            buffer: String::with_capacity(capacity),
+        }
+    }
+
+    /// Check if the internal buffer is empty
+    pub(super) fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Consume Self and return the formatted buffer
+    pub(super) fn into_buffer(mut self) -> String {
+        let rewrite_buffer = std::mem::take(&mut self.buffer);
+
+        let Some(max_width) = self.max_width else {
+            // We didn't configure a max_width, so just return the buffer
+            return rewrite_buffer;
+        };
+
+        let all_lines_with_max_width = rewrite_buffer.lines().all(|l| l.len() <= max_width);
+
+        if all_lines_with_max_width {
+            // Don't need to wrap any lines
+            return rewrite_buffer;
+        }
+
+        let mut output_buffer = String::with_capacity(rewrite_buffer.capacity());
+
+        let wrap_options = TextWrapOptions::new(max_width)
+            .break_words(false)
+            .word_separator(textwrap::WordSeparator::AsciiSpace)
+            .wrap_algorithm(textwrap::WrapAlgorithm::FirstFit);
+
+        let mut split_on_hard_breaks = rewrite_buffer.split(MARKDOWN_HARD_BREAK).peekable();
+
+        while let Some(text) = split_on_hard_breaks.next() {
+            let has_next = split_on_hard_breaks.peek().is_some();
+            let wrapped_text = textwrap::fill(text, wrap_options.clone());
+            output_buffer.push_str(&wrapped_text);
+            if has_next {
+                output_buffer.push_str(MARKDOWN_HARD_BREAK);
+            }
+        }
+
+        output_buffer
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,34 @@
-mod common;
+use crate::{rewrite_markdown, rewrite_markdown_with_builder, FormatterBuilder};
 
-use markdown_fmt::rewrite_markdown;
+#[test]
+fn reformat() {
+    let input = r##"#  Hello World!
+1.  Hey [ there! ]
+2.  what's going on?
+
+<p> and a little bit of HTML </p>
+
+```rust
+fn main() {}
+```
+[
+    there!
+    ]: htts://example.com "Yoooo"
+"##;
+    let expected = r##"# Hello World!
+1. Hey [there!]
+2. what's going on?
+
+<p> and a little bit of HTML </p>
+
+```rust
+fn main() {}
+```
+[there!]: htts://example.com "Yoooo"
+"##;
+    let rewrite = rewrite_markdown(input).unwrap();
+    assert_eq!(rewrite, expected)
+}
 
 #[test]
 fn check_markdown_formatting() {
@@ -12,7 +40,8 @@ fn check_markdown_formatting() {
     {
         let filename = file.file_name();
         let input = std::fs::read_to_string(file.path()).unwrap();
-        let formatted_input = rewrite_markdown(&input).unwrap();
+        let builder = FormatterBuilder::default();
+        let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();
         let target_file = format!("tests/target/{}", filename.to_str().unwrap());
         let expected_output = std::fs::read_to_string(target_file).unwrap();
 
@@ -33,7 +62,8 @@ fn idempotence_test() {
         .map(Result::unwrap)
     {
         let input = std::fs::read_to_string(file.path()).unwrap();
-        let formatted_input = rewrite_markdown(&input).unwrap();
+        let builder = FormatterBuilder::default();
+        let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();
 
         if formatted_input != input {
             errors += 1;

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -1955,7 +1955,7 @@ bbb"##);
 #[test]
 fn markdown_paragraphs_226() {
     // https://spec.commonmark.org/0.30/#example-226
-    test_identical_markdown_events!("aaa     \nbbb     ");
+    test_identical_markdown_events!("aaa     \nbbb     ","aaa     \nbbb");
 }
 
 #[test]
@@ -5030,7 +5030,7 @@ fn markdown_hard_line_breaks_644() {
 #[test]
 fn markdown_hard_line_breaks_645() {
     // https://spec.commonmark.org/0.30/#example-645
-    test_identical_markdown_events!("foo  ");
+    test_identical_markdown_events!("foo  ",r##"foo"##);
 }
 
 #[test]

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1734,7 +1734,7 @@ bbb"##);
 #[test]
 fn gfm_markdown_paragraphs_196() {
     // https://github.github.com/gfm/#example-196
-    test_identical_markdown_events!("aaa     \nbbb     ");
+    test_identical_markdown_events!("aaa     \nbbb     ","aaa     \nbbb");
 }
 
 #[test]
@@ -5168,7 +5168,7 @@ fn gfm_markdown_hard_line_breaks_664() {
 #[test]
 fn gfm_markdown_hard_line_breaks_665() {
     // https://github.github.com/gfm/#example-665
-    test_identical_markdown_events!("foo  ");
+    test_identical_markdown_events!("foo  ",r##"foo"##);
 }
 
 #[test]

--- a/tests/source/config/max_width/50.md
+++ b/tests/source/config/max_width/50.md
@@ -1,0 +1,23 @@
+<!-- :max_width:50 -->
+
+<!-- from https://www.lipsum.com/ -->
+
+# The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+
+# Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?"
+
+# 1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?"
+
+# Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat."
+
+# 1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains."

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -1892,6 +1892,7 @@
   },
   {
     "markdown": "aaa     \nbbb     \n",
+    "formattedMarkdown": "aaa     \nbbb",
     "html": "<p>aaa<br />\nbbb</p>\n",
     "example": 226,
     "start_line": 3619,
@@ -5316,6 +5317,7 @@
   },
   {
     "markdown": "foo  \n",
+    "formattedMarkdown": "foo",
     "html": "<p>foo</p>\n",
     "example": 645,
     "start_line": 9334,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -1832,6 +1832,7 @@
   },
   {
     "markdown": "aaa     \nbbb     \n",
+    "formattedMarkdown": "aaa     \nbbb",
     "html": "<p>aaa<br />\nbbb</p>\n",
     "example": 196,
     "start_line": 3274,
@@ -6141,6 +6142,7 @@
   },
   {
     "markdown": "foo  \n",
+    "formattedMarkdown": "foo",
     "html": "<p>foo</p>\n",
     "example": 665,
     "start_line": 9791,

--- a/tests/target/config/max_width/50.md
+++ b/tests/target/config/max_width/50.md
@@ -1,0 +1,107 @@
+<!-- :max_width:50 -->
+
+<!-- from https://www.lipsum.com/ -->
+
+# The standard Lorem Ipsum passage, used since the 1500s
+
+"Lorem ipsum dolor sit amet, consectetur
+adipiscing elit, sed do eiusmod tempor incididunt
+ut labore et dolore magna aliqua. Ut enim ad minim
+veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat. Duis aute
+irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id
+est laborum."
+
+# Section 1.10.32 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"Sed ut perspiciatis unde omnis iste natus error
+sit voluptatem accusantium doloremque laudantium,
+totam rem aperiam, eaque ipsa quae ab illo
+inventore veritatis et quasi architecto beatae
+vitae dicta sunt explicabo. Nemo enim ipsam
+voluptatem quia voluptas sit aspernatur aut odit
+aut fugit, sed quia consequuntur magni dolores eos
+qui ratione voluptatem sequi nesciunt. Neque porro
+quisquam est, qui dolorem ipsum quia dolor sit
+amet, consectetur, adipisci velit, sed quia non
+numquam eius modi tempora incidunt ut labore et
+dolore magnam aliquam quaerat voluptatem. Ut enim
+ad minima veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut
+aliquid ex ea commodi consequatur? Quis autem vel
+eum iure reprehenderit qui in ea voluptate velit
+esse quam nihil molestiae consequatur, vel illum
+qui dolorem eum fugiat quo voluptas nulla
+pariatur?"
+
+# 1914 translation by H. Rackham
+
+"But I must explain to you how all this mistaken
+idea of denouncing pleasure and praising pain was
+born and I will give you a complete account of the
+system, and expound the actual teachings of the
+great explorer of the truth, the master-builder of
+human happiness. No one rejects, dislikes, or
+avoids pleasure itself, because it is pleasure,
+but because those who do not know how to pursue
+pleasure rationally encounter consequences that
+are extremely painful. Nor again is there anyone
+who loves or pursues or desires to obtain pain of
+itself, because it is pain, but because
+occasionally circumstances occur in which toil and
+pain can procure him some great pleasure. To take
+a trivial example, which of us ever undertakes
+laborious physical exercise, except to obtain some
+advantage from it? But who has any right to find
+fault with a man who chooses to enjoy a pleasure
+that has no annoying consequences, or one who
+avoids a pain that produces no resultant
+pleasure?"
+
+# Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
+
+"At vero eos et accusamus et iusto odio
+dignissimos ducimus qui blanditiis praesentium
+voluptatum deleniti atque corrupti quos dolores et
+quas molestias excepturi sint occaecati cupiditate
+non provident, similique sunt in culpa qui officia
+deserunt mollitia animi, id est laborum et dolorum
+fuga. Et harum quidem rerum facilis est et
+expedita distinctio. Nam libero tempore, cum
+soluta nobis est eligendi optio cumque nihil
+impedit quo minus id quod maxime placeat facere
+possimus, omnis voluptas assumenda est, omnis
+dolor repellendus. Temporibus autem quibusdam et
+aut officiis debitis aut rerum necessitatibus
+saepe eveniet ut et voluptates repudiandae sint et
+molestiae non recusandae. Itaque earum rerum hic
+tenetur a sapiente delectus, ut aut reiciendis
+voluptatibus maiores alias consequatur aut
+perferendis doloribus asperiores repellat."
+
+# 1914 translation by H. Rackham
+
+"On the other hand, we denounce with righteous
+indignation and dislike men who are so beguiled
+and demoralized by the charms of pleasure of the
+moment, so blinded by desire, that they cannot
+foresee the pain and trouble that are bound to
+ensue; and equal blame belongs to those who fail
+in their duty through weakness of will, which is
+the same as saying through shrinking from toil and
+pain. These cases are perfectly simple and easy to
+distinguish. In a free hour, when our power of
+choice is untrammelled and when nothing prevents
+our being able to do what we like best, every
+pleasure is to be welcomed and every pain avoided.
+But in certain circumstances and owing to the
+claims of duty or the obligations of business it
+will frequently occur that pleasures have to be
+repudiated and annoyances accepted. The wise man
+therefore always holds in these matters to this
+principle of selection: he rejects pleasures to
+secure other greater pleasures, or else he endures
+pains to avoid worse pains."


### PR DESCRIPTION
I'm very happy with these changes. Now we can configure when our paragraphs should wrap!

One limitation to note, is that [tight](https://spec.commonmark.org/0.30/#tight) lists don't include paragraphs, so they won't be wrapped, at least not yet. I have plans to add an adapter to the event iterator so that I can add synthetic paragraph events to enable wrapping.