### PR TITLE
Add (Event, Range) adapter to transform tight lists into loose lists

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,0 +1,3 @@
+mod loose_list;
+
+pub(crate) use loose_list::LooseListExt;

--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -1,0 +1,469 @@
+use pulldown_cmark::{Event, Tag};
+use std::collections::VecDeque;
+use std::iter::Peekable;
+
+/// Conveniently turn any iterator that returns (Event, Range) into a LooseListAdapter
+pub(crate) trait LooseListExt<'input, I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    fn all_loose_lists(self) -> LooseListAdapter<'input, I>;
+}
+
+// Blanket impl for all iterators
+impl<'input, I> LooseListExt<'input, I> for I
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    fn all_loose_lists(self) -> LooseListAdapter<'input, I> {
+        LooseListAdapter::new(self)
+    }
+}
+
+/// Converts [`tight`] lists into [`loose`] lists.
+///
+/// A loose list contains items that are separated by newlines.
+/// See <https://spec.commonmark.org/0.30/#list> fot more about `tight` vs `loose` lists.
+///
+/// [`tight`]: https://spec.commonmark.org/0.30/#tight
+/// [`loose`]: https://spec.commonmark.org/0.30/#loose
+///
+/// ## Loose List
+///
+/// ```markdown
+/// * a
+///
+///   b
+/// ```
+///
+/// The snippet would generate the following Markdown Events
+///
+/// ```text
+/// Start(List(None))
+/// event=Start(Item)
+/// event=Start(Paragraph)
+/// event=Text(Borrowed("a"))
+/// event=End(Paragraph)
+/// event=Start(Paragraph)
+/// event=Text(Borrowed("b"))
+/// event=End(Paragraph)
+/// event=End(Item)
+/// event=End(List(None))
+/// ```
+///
+/// ## Tight List
+///
+/// ```markdown
+/// * c
+///   d
+/// ```
+///
+/// This snippet generates the following Markdown Events. **Note** that there aren't any
+/// `Paragraph` events, and that's how we know the list item is tight.
+///
+/// ```text
+/// event=Start(List(None))
+/// event=Start(Item)
+/// event=Text(Borrowed("c"))
+/// event=SoftBreak
+/// event=Text(Borrowed("d"))
+/// event=End(Item)
+/// event=End(List(None))
+/// ```
+///
+/// ## Transformation
+///
+/// The goal of the [LooseListAdapter] is to convert all tight list items into loose list items
+/// by wrapping them in paragraph events.
+///
+/// ```markdown
+/// * e
+///   f
+/// ```
+///
+/// The adapter will generate the following events
+///
+/// ```text
+/// event=Start(List(None))
+/// event=Start(Item)
+/// event=Start(Paragraph)
+/// event=Text(Borrowed("c"))
+/// event=SoftBreak
+/// event=Text(Borrowed("d"))
+/// event=End(Paragraph)
+/// event=End(Item)
+/// event=End(List(None))
+/// ```
+pub(crate) struct LooseListAdapter<'input, I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    /// Inner iterator that return Events
+    inner: Peekable<I>,
+    /// Represents offsets into the intermediate_events
+    loose_list_stack: Vec<Option<usize>>,
+    /// Keeps track of events until we're ready to start returning them.
+    stashed_events: VecDeque<(Event<'input>, std::ops::Range<usize>)>,
+}
+
+impl<'input, I> LooseListAdapter<'input, I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    pub(super) fn new(inner: I) -> Self {
+        Self {
+            inner: inner.peekable(),
+            loose_list_stack: vec![],
+            stashed_events: VecDeque::new(),
+        }
+    }
+    /// Check if the next event denotes a tight list.
+    ///
+    /// this should only be called when in the context of a list item.
+    fn is_tight_list(event: &Event<'_>) -> bool {
+        match event {
+            Event::Text(_)
+            | Event::Code(_)
+            | Event::FootnoteReference(_)
+            | Event::TaskListMarker(_)
+            | Event::Start(Tag::Link(..)) => true,
+            Event::Html(text) => is_single_html_tag(text),
+            _ => false,
+        }
+    }
+}
+
+/// Check if the HTML content is a single tag. For example, `<{tag}>` or `</{tag}>`.
+fn is_single_html_tag(html: &str) -> bool {
+    // A hacky way to figure out if this is an inline html tag, but I think it works!
+    html.starts_with('<')
+        && html.ends_with('>')
+        && html.bytes().filter(|b| matches!(b, b'<' | b'>')).count() == 2
+}
+
+macro_rules! push_end_paragraph {
+    ($index:expr, $stashed_events:expr, $end:expr) => {
+        if let Some((paragraph, paragraph_range)) = $stashed_events.get_mut($index) {
+            debug_assert!(matches!(paragraph, Event::Start(Tag::Paragraph)));
+
+            let full_range = paragraph_range.start..$end;
+            *paragraph_range = full_range.clone();
+
+            let paragraph_end = Event::End(Tag::Paragraph);
+            $stashed_events.push_back((paragraph_end, full_range))
+        } else {
+            panic!("We should have stashed a Start(Paragraph) event");
+        }
+    };
+}
+
+macro_rules! maybe_push_start_paragraph {
+    ($self:expr, $name:ident) => {
+        // FIXME(ytmimi) let-chains would make this nicer to write
+        if let Some(last @ None) = $self.loose_list_stack.last_mut() {
+            if let Some((next_event, next_range)) = $self.inner.peek() {
+                if $name::is_tight_list(next_event) {
+                    let index = $self.stashed_events.len();
+                    *last = Some(index);
+
+                    // produce a synthetic `Start(Paragraph)` event.
+                    $self
+                        .stashed_events
+                        .push_back((Event::Start(Tag::Paragraph), next_range.clone()));
+                }
+            }
+        }
+    };
+}
+
+impl<'input, I> Iterator for LooseListAdapter<'input, I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    type Item = (Event<'input>, std::ops::Range<usize>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let next @ Some(_) = self.stashed_events.pop_front() {
+            return next;
+        }
+
+        loop {
+            let (current_event, current_range) = match self.inner.next() {
+                Some(current) => current,
+                None => {
+                    return self.stashed_events.pop_front();
+                }
+            };
+
+            tracing::debug!(event=?current_event, range=?current_range);
+
+            match current_event {
+                Event::Start(Tag::Item) => {
+                    self.stashed_events
+                        .push_back((current_event, current_range));
+
+                    // FIXME(ytmimi) let-chains would make this nicer to write
+                    match self.inner.peek() {
+                        Some((next_event, next_range)) if Self::is_tight_list(next_event) => {
+                            // Use this index later to update the `Start(Paragraph)`'s end range
+                            let index = self.stashed_events.len();
+                            self.loose_list_stack.push(Some(index));
+
+                            // produce a synthetic `Start(Paragraph)` event.
+                            self.stashed_events
+                                .push_back((Event::Start(Tag::Paragraph), next_range.clone()));
+                        }
+                        _ => {
+                            self.loose_list_stack.push(None);
+                        }
+                    }
+                }
+                Event::End(Tag::Item) => {
+                    self.stashed_events
+                        .push_back((current_event, current_range));
+
+                    if self.loose_list_stack.is_empty() {
+                        // Once the stack is empty it's fine to start returning events that have
+                        // been stashed. Trying to return before this point would lead to errors,
+                        // becuase we the loose_list_stack holds indexes into the stashed_events.
+                        return self.stashed_events.pop_front();
+                    }
+                }
+                Event::End(
+                    Tag::Heading(..)
+                    | Tag::List(_)
+                    | Tag::BlockQuote
+                    | Tag::CodeBlock(_)
+                    | Tag::Table(_),
+                ) => {
+                    self.stashed_events
+                        .push_back((current_event, current_range));
+                    maybe_push_start_paragraph!(self, Self);
+                }
+                Event::Html(ref text) if !is_single_html_tag(text) => {
+                    self.stashed_events
+                        .push_back((current_event, current_range));
+                    maybe_push_start_paragraph!(self, Self);
+                }
+                _ => {
+                    self.stashed_events
+                        .push_back((current_event, current_range.clone()));
+
+                    if self.loose_list_stack.is_empty() {
+                        return self.stashed_events.pop_front();
+                    }
+
+                    // Match on events that could interrupt a paragraph, and if we're currently
+                    // converting a "tight" list to a "loose" list, then push an `End(Paragraph)`
+                    match self.inner.peek() {
+                        Some((Event::End(Tag::Item), _)) => {
+                            // NOTE that we pop off of the loose_list_stack instead of peeking at
+                            // it like we do in the other arms
+                            if let Some(Some(index)) = self.loose_list_stack.pop() {
+                                push_end_paragraph!(index, self.stashed_events, current_range.end)
+                            }
+                        }
+                        Some((
+                            Event::Start(
+                                Tag::Heading(..)
+                                | Tag::List(_)
+                                | Tag::BlockQuote
+                                | Tag::CodeBlock(_)
+                                | Tag::Table(_),
+                            ),
+                            _,
+                        )) => {
+                            if let Some(Some(index)) =
+                                self.loose_list_stack.last_mut().map(|i| i.take())
+                            {
+                                push_end_paragraph!(index, self.stashed_events, current_range.end)
+                            }
+                        }
+                        Some((Event::Html(ref html), _)) if !is_single_html_tag(html) => {
+                            if let Some(Some(index)) =
+                                self.loose_list_stack.last_mut().map(|i| i.take())
+                            {
+                                push_end_paragraph!(index, self.stashed_events, current_range.end)
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::Config;
+    use crate::formatter::FormatState;
+    use crate::test::get_test_files;
+    use std::borrow::Cow;
+    use std::path::PathBuf;
+
+    macro_rules! check_unchanged_events {
+        ($markdown:literal) => {
+            let mut options = pulldown_cmark::Options::all();
+            options.remove(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION);
+
+            let input = pulldown_cmark::Parser::new_ext($markdown, options.clone())
+                .into_offset_iter()
+                .collect::<Vec<_>>();
+            let output = pulldown_cmark::Parser::new_ext($markdown, options)
+                .into_offset_iter()
+                .all_loose_lists()
+                .collect::<Vec<_>>();
+
+            assert_eq!(input, output)
+        };
+    }
+
+    #[test]
+    fn check_unchanged() {
+        check_unchanged_events!("");
+        check_unchanged_events!("a");
+        check_unchanged_events!(">");
+        check_unchanged_events!("*");
+        check_unchanged_events!("+");
+        check_unchanged_events!("-");
+        check_unchanged_events!("> *");
+        check_unchanged_events!("> +");
+        check_unchanged_events!("> -");
+        check_unchanged_events!("# header");
+        check_unchanged_events!("* ## header");
+        check_unchanged_events!("+ ## header");
+        check_unchanged_events!("- ## header");
+        check_unchanged_events!(
+            r"
+- ```text
+  ```
+"
+        );
+        check_unchanged_events!(
+            r"
+- ```text
+  ```
+  >
+  -
+  ```text
+  another code block
+  ```
+ <div>block level html is also unchanged</div>
+"
+        );
+
+        check_unchanged_events!(
+            r"
+-
+  -
+    -
+      -
+"
+        );
+        check_unchanged_events!(
+            r"
+| col 1 | col 2 |
+| ----- | ----- |
+| 1     | 2     |
+"
+        );
+
+        check_unchanged_events!(
+            r"
+- | table | heading is longer than content (in list) |
+  | ----- | ---------------------------------------- |
+  | val   | x                                        |
+"
+        );
+
+        check_unchanged_events!("    indent code block");
+        check_unchanged_events!(
+            r"
+* a
+
+  b
+"
+        );
+
+        check_unchanged_events!(
+            r#"
+* This is Already a loose list
+
+  <span>some inline </span> html.
+
+  ```rust
+  fn main() {
+    println!("hello world!");
+  }
+  ```
+"#
+        );
+    }
+
+    const SEPARATOR: &str = "==========";
+
+    /// Make sure that the adapter generates reasonable events when converting tight lists
+    /// into loose lists.
+    #[test]
+    fn check_adapter_events() {
+        let mut file = PathBuf::from(std::file!());
+        file.pop();
+        let test_dir = file.join("test/loose_list");
+        for file in get_test_files(test_dir, "txt") {
+            let content = std::fs::read_to_string(&file).unwrap();
+            let (markdown, expected_events) = content.split_once(SEPARATOR).unwrap();
+
+            let mut options = pulldown_cmark::Options::all();
+            options.remove(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION);
+
+            let events = pulldown_cmark::Parser::new_ext(markdown, options)
+                .into_offset_iter()
+                .all_loose_lists();
+
+            if std::env::var("GENERATE_EVENTS").is_ok() {
+                // write the events out to the file
+                let mut output: Vec<Cow<'_, str>> = vec![
+                    markdown.trim().into(),
+                    "".into(),
+                    SEPARATOR.into(),
+                    "".into(),
+                ];
+
+                for (event, range) in events {
+                    output.push(format!("event={event:?} range={range:?}").into())
+                }
+                output.push("".into());
+                std::fs::write(file, &output.join("\n")).unwrap();
+            } else {
+                for ((event, range), line) in events.zip(expected_events.trim().lines()) {
+                    assert_eq!(format!("event={event:?} range={range:?}"), line);
+                }
+            }
+
+            // Get the events before formatting
+            let pre_events = pulldown_cmark::Parser::new_ext(markdown, options).collect::<Vec<_>>();
+
+            // Use the `all_loose_lists` adapter when formatting
+            let adapted_events = pulldown_cmark::Parser::new_ext(markdown, options)
+                .into_offset_iter()
+                .all_loose_lists();
+            let fmt_state = FormatState::new(
+                markdown,
+                Config::default(),
+                |_, s| s,
+                adapted_events,
+                vec![],
+            );
+
+            let output = fmt_state.format().unwrap();
+
+            // Get the events after formatting
+            let pos_events = pulldown_cmark::Parser::new_ext(&output, options).collect::<Vec<_>>();
+
+            // Make sure the events haven't changed after formatting
+            assert_eq!(pre_events, pos_events)
+        }
+    }
+}

--- a/src/adapters/test/loose_list/basic.md
+++ b/src/adapters/test/loose_list/basic.md
@@ -1,0 +1,14 @@
+* a
+  b
+
+==========
+
+event=Start(List(None)) range=0..9
+event=Start(Item) range=0..9
+event=Start(Paragraph) range=2..7
+event=Text(Borrowed("a")) range=2..3
+event=SoftBreak range=3..4
+event=Text(Borrowed("b")) range=6..7
+event=End(Paragraph) range=2..7
+event=End(Item) range=0..9
+event=End(List(None)) range=0..9

--- a/src/adapters/test/loose_list/deeply_nested_tight_list.md
+++ b/src/adapters/test/loose_list/deeply_nested_tight_list.md
@@ -1,0 +1,67 @@
+- a
+  + b
+    - c
+      + d
+        - e
+          + f
+            - g
+              + h
+
+==========
+
+event=Start(List(None)) range=0..89
+event=Start(Item) range=0..89
+event=Start(Paragraph) range=2..3
+event=Text(Borrowed("a")) range=2..3
+event=End(Paragraph) range=2..3
+event=Start(List(None)) range=6..89
+event=Start(Item) range=6..89
+event=Start(Paragraph) range=8..9
+event=Text(Borrowed("b")) range=8..9
+event=End(Paragraph) range=8..9
+event=Start(List(None)) range=14..89
+event=Start(Item) range=14..89
+event=Start(Paragraph) range=16..17
+event=Text(Borrowed("c")) range=16..17
+event=End(Paragraph) range=16..17
+event=Start(List(None)) range=24..89
+event=Start(Item) range=24..89
+event=Start(Paragraph) range=26..27
+event=Text(Borrowed("d")) range=26..27
+event=End(Paragraph) range=26..27
+event=Start(List(None)) range=36..89
+event=Start(Item) range=36..89
+event=Start(Paragraph) range=38..39
+event=Text(Borrowed("e")) range=38..39
+event=End(Paragraph) range=38..39
+event=Start(List(None)) range=50..89
+event=Start(Item) range=50..89
+event=Start(Paragraph) range=52..53
+event=Text(Borrowed("f")) range=52..53
+event=End(Paragraph) range=52..53
+event=Start(List(None)) range=66..89
+event=Start(Item) range=66..89
+event=Start(Paragraph) range=68..69
+event=Text(Borrowed("g")) range=68..69
+event=End(Paragraph) range=68..69
+event=Start(List(None)) range=84..89
+event=Start(Item) range=84..89
+event=Start(Paragraph) range=86..87
+event=Text(Borrowed("h")) range=86..87
+event=End(Paragraph) range=86..87
+event=End(Item) range=84..89
+event=End(List(None)) range=84..89
+event=End(Item) range=66..89
+event=End(List(None)) range=66..89
+event=End(Item) range=50..89
+event=End(List(None)) range=50..89
+event=End(Item) range=36..89
+event=End(List(None)) range=36..89
+event=End(Item) range=24..89
+event=End(List(None)) range=24..89
+event=End(Item) range=14..89
+event=End(List(None)) range=14..89
+event=End(Item) range=6..89
+event=End(List(None)) range=6..89
+event=End(Item) range=0..89
+event=End(List(None)) range=0..89

--- a/src/adapters/test/loose_list/headers.md
+++ b/src/adapters/test/loose_list/headers.md
@@ -1,0 +1,30 @@
+- # Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+  some text after the heading
+
+> - some text before the heading
+>   # Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+
+==========
+
+event=Start(List(None)) range=0..92
+event=Start(Item) range=0..92
+event=Start(Heading(H1, None, [])) range=2..61
+event=Text(Borrowed("Lorem ipsum dolor sit amet, consectetur adipiscing elit,")) range=4..60
+event=End(Heading(H1, None, [])) range=2..61
+event=Start(Paragraph) range=63..90
+event=Text(Borrowed("some text after the heading")) range=63..90
+event=End(Paragraph) range=63..90
+event=End(Item) range=0..92
+event=End(List(None)) range=0..92
+event=Start(BlockQuote) range=92..188
+event=Start(List(None)) range=94..188
+event=Start(Item) range=94..188
+event=Start(Paragraph) range=96..124
+event=Text(Borrowed("some text before the heading")) range=96..124
+event=End(Paragraph) range=96..124
+event=Start(Heading(H1, None, [])) range=129..188
+event=Text(Borrowed("Lorem ipsum dolor sit amet, consectetur adipiscing elit,")) range=131..187
+event=End(Heading(H1, None, [])) range=129..188
+event=End(Item) range=94..188
+event=End(List(None)) range=94..188
+event=End(BlockQuote) range=92..188

--- a/src/adapters/test/loose_list/inline_html.md
+++ b/src/adapters/test/loose_list/inline_html.md
@@ -1,0 +1,34 @@
+-
+  some html<br> some more stuff some
+  <span><span>html</span> </span>
+  <p> some more html</p>
+  <p>
+    some
+    more
+    html
+  </p>
+
+==========
+
+event=Start(List(None)) range=0..139
+event=Start(Item) range=0..139
+event=Start(Paragraph) range=4..72
+event=Text(Borrowed("some html")) range=4..13
+event=Html(Borrowed("<br>")) range=13..17
+event=Text(Borrowed(" some more stuff some")) range=17..38
+event=SoftBreak range=38..39
+event=Html(Borrowed("<span>")) range=41..47
+event=Html(Borrowed("<span>")) range=47..53
+event=Text(Borrowed("html")) range=53..57
+event=Html(Borrowed("</span>")) range=57..64
+event=Text(Borrowed(" ")) range=64..65
+event=Html(Borrowed("</span>")) range=65..72
+event=End(Paragraph) range=4..72
+event=Html(Borrowed("<p> some more html</p>\n")) range=75..98
+event=Html(Borrowed("<p>\n")) range=100..104
+event=Html(Borrowed("  some\n")) range=106..113
+event=Html(Borrowed("  more\n")) range=115..122
+event=Html(Borrowed("  html\n")) range=124..131
+event=Html(Borrowed("</p>\n")) range=133..138
+event=End(Item) range=0..139
+event=End(List(None)) range=0..139

--- a/src/adapters/test/loose_list/link.md
+++ b/src/adapters/test/loose_list/link.md
@@ -1,0 +1,13 @@
+- [some link](/url)
+
+==========
+
+event=Start(List(None)) range=0..21
+event=Start(Item) range=0..21
+event=Start(Paragraph) range=2..19
+event=Start(Link(Inline, Borrowed("/url"), Borrowed(""))) range=2..19
+event=Text(Borrowed("some link")) range=3..12
+event=End(Link(Inline, Borrowed("/url"), Borrowed(""))) range=2..19
+event=End(Paragraph) range=2..19
+event=End(Item) range=0..21
+event=End(List(None)) range=0..21

--- a/src/adapters/test/loose_list/taks_list.md
+++ b/src/adapters/test/loose_list/taks_list.md
@@ -1,0 +1,23 @@
+# TODOs
+- [x] done!
+- [ ] not done :'(
+
+==========
+
+event=Start(Heading(H1, None, [])) range=0..8
+event=Text(Borrowed("TODOs")) range=2..7
+event=End(Heading(H1, None, [])) range=0..8
+event=Start(List(None)) range=8..40
+event=Start(Item) range=8..20
+event=Start(Paragraph) range=10..19
+event=TaskListMarker(true) range=10..13
+event=Text(Borrowed("done!")) range=14..19
+event=End(Paragraph) range=10..19
+event=End(Item) range=8..20
+event=Start(Item) range=20..40
+event=Start(Paragraph) range=22..38
+event=TaskListMarker(false) range=22..25
+event=Text(Borrowed("not done :'(")) range=26..38
+event=End(Paragraph) range=22..38
+event=End(Item) range=20..40
+event=End(List(None)) range=8..40

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel};
 use pulldown_cmark::{LinkDef, LinkType, Options, Parser, Tag};
 
+use crate::adapters::LooseListExt;
 use crate::builder::CodeBlockFormatter;
 use crate::config::Config;
 use crate::links;
@@ -74,7 +75,7 @@ impl MarkdownFormatter {
             })
             .collect::<Vec<_>>();
 
-        let iter = parser.into_offset_iter();
+        let iter = parser.into_offset_iter().all_loose_lists();
 
         let fmt_state = FormatState::new(
             input,
@@ -482,7 +483,7 @@ where
     F: Fn(&str, String) -> String,
     I: Iterator<Item = (Event<'i>, std::ops::Range<usize>)>,
 {
-    fn new(
+    pub(crate) fn new(
         input: &'i str,
         config: Config,
         code_block_formatter: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 //! # Ok::<(), std::fmt::Error>(())
 //! ````
 
+mod adapters;
 mod builder;
 mod config;
 mod escape;

--- a/src/test.rs
+++ b/src/test.rs
@@ -58,19 +58,22 @@ fn main() {}
     assert_eq!(rewrite, expected)
 }
 
-fn get_test_files<P: AsRef<Path>>(path: P) -> impl Iterator<Item = PathBuf> {
+pub(crate) fn get_test_files<P: AsRef<Path>>(
+    path: P,
+    extension: &str,
+) -> impl Iterator<Item = PathBuf> {
     SearchBuilder::default()
-        .ext(".md")
+        .ext(extension)
         .location(path)
         .build()
-        .map(|f| PathBuf::from(f))
+        .map(PathBuf::from)
 }
 
 #[test]
 fn check_markdown_formatting() {
     let mut errors = 0;
 
-    for file in get_test_files("tests/source") {
+    for file in get_test_files("tests/source", "md") {
         let input = std::fs::read_to_string(&file).unwrap();
         let builder = FormatterBuilder::from_leading_config_comments(&input);
         let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();
@@ -93,7 +96,7 @@ fn check_markdown_formatting() {
 fn idempotence_test() {
     let mut errors = 0;
 
-    for file in get_test_files("tests/target") {
+    for file in get_test_files("tests/target", "md") {
         let input = std::fs::read_to_string(&file).unwrap();
         let builder = FormatterBuilder::from_leading_config_comments(&input);
         let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();

--- a/tests/source/wrap_tight_list.md
+++ b/tests/source/wrap_tight_list.md
@@ -1,0 +1,16 @@
+<!-- :max_width:50 -->
+
+- Item 1 is a generic example used to illustrate a point.
+- Item 2 serves a similar purpose, adding depth to the demonstration.
+- Item 3 concludes the list, providing a comprehensive overview.
+- Some text with inline html.<br> Some more <span>stuff</span>
+  <!-- HTML blocks like comments and <p> tags are not wrapped because they aren't parsed as paragraphs... -->
+  <p> some more html</p>
+  <p>
+    some
+    more
+    html
+  </p>
+  ```text
+  Since there are no spaces between any of of the items in the list, this is considered a tight list
+  ```

--- a/tests/target/wrap_tight_list.md
+++ b/tests/target/wrap_tight_list.md
@@ -1,0 +1,20 @@
+<!-- :max_width:50 -->
+
+- Item 1 is a generic example used to illustrate a
+  point.
+- Item 2 serves a similar purpose, adding depth to
+  the demonstration.
+- Item 3 concludes the list, providing a
+  comprehensive overview.
+- Some text with inline html.<br> Some more
+  <span>stuff</span>
+  <!-- HTML blocks like comments and <p> tags are not wrapped because they aren't parsed as paragraphs... -->
+  <p> some more html</p>
+  <p>
+    some
+    more
+    html
+  </p>
+  ```text
+  Since there are no spaces between any of of the items in the list, this is considered a tight list
+  ```


### PR DESCRIPTION
The adapter inserts synthetic `Start(Paragraph)` and `End(Paragraph)` events to apply the wrapping logic implemented by the `crate::paragraph::Paragraph` struct to tight lists, which normally don't have their items wrapped in `Paragraph` Events.