### PR TITLE
Handle edge case with reference link definition titles

### DIFF
--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -1802,12 +1802,11 @@ fn markdown_link_reference_definitions_209() {
 }
 
 // FIXME(ytmim) the "title" is duplcated here
-#[ignore]
 #[test]
 fn markdown_link_reference_definitions_210() {
     // https://spec.commonmark.org/0.30/#example-210
     test_identical_markdown_events!(r##"[foo]: /url
-"title" ok"##,r##"[foo]: /url "title""title" ok"##);
+"title" ok"##);
 }
 
 #[test]

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1572,12 +1572,11 @@ fn gfm_markdown_link_reference_definitions_178() {
 }
 
 // FIXME(ytmim) the "title" is duplcated here
-#[ignore]
 #[test]
 fn gfm_markdown_link_reference_definitions_179() {
     // https://github.github.com/gfm/#example-179
     test_identical_markdown_events!(r##"[foo]: /url
-"title" ok"##,r##"[foo]: /url "title""title" ok"##);
+"title" ok"##);
 }
 
 #[test]

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -1755,14 +1755,11 @@
   },
   {
     "markdown": "[foo]: /url\n\"title\" ok\n",
-    "formattedMarkdown": "[foo]: /url \"title\"\"title\" ok",
     "html": "<p>&quot;title&quot; ok</p>\n",
     "example": 210,
     "start_line": 3397,
     "end_line": 3402,
-    "section": "Link reference definitions",
-    "skip": true,
-    "comment": "FIXME(ytmim) the \"title\" is duplcated here"
+    "section": "Link reference definitions"
   },
   {
     "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -1669,14 +1669,11 @@
   },
   {
     "markdown": "[foo]: /url\n\"title\" ok\n",
-    "formattedMarkdown": "[foo]: /url \"title\"\"title\" ok",
     "html": "<p>&quot;title&quot; ok</p>\n",
     "example": 179,
     "start_line": 3040,
     "end_line": 3045,
     "section": "Link reference definitions",
-    "skip": true,
-    "comment": "FIXME(ytmim) the \"title\" is duplcated here",
     "extensions": []
   },
   {


### PR DESCRIPTION
Markdown spec examples [209] and [210] help to illustrate that when there's any text besides spaces, tabs, or newlines after something that looks like a link reference definition title, either the entire definition isn't a reference ([209]), or the quoted string that looks like a title is actually part of the following paragraph ([210]).

This has been a long standing issue and I was ignoring these tests because they were producing incorrect markdown. Now that I'm accounting for this edge case these tests pass!

[209]: https://spec.commonmark.org/0.30/#example-209
[210]: https://spec.commonmark.org/0.30/#example-209