### PR TITLE
Improve link reference definition recovery

### DIFF
--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -449,13 +449,7 @@ mod test {
             let adapted_events = pulldown_cmark::Parser::new_ext(markdown, options)
                 .into_offset_iter()
                 .all_loose_lists();
-            let fmt_state = FormatState::new(
-                markdown,
-                Config::default(),
-                |_, s| s,
-                adapted_events,
-                vec![],
-            );
+            let fmt_state = FormatState::new(markdown, Config::default(), |_, s| s, adapted_events);
 
             let output = fmt_state.format().unwrap();
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -197,3 +197,847 @@ fn split_inline_url_from_title(
         Some((title.to_string(), quote)),
     ))
 }
+
+struct LinkReferenceDefinitionBuilder<'a> {
+    label: Option<LinkLines<'a>>,
+    destination: Option<(LinkDestination<'a>, std::ops::Range<usize>)>,
+    title: Option<LinkTitle<'a>>,
+}
+
+impl<'a> LinkReferenceDefinitionBuilder<'a> {
+    fn new() -> Self {
+        Self {
+            label: None,
+            destination: None,
+            title: None,
+        }
+    }
+
+    fn set_label(&mut self, label: Cow<'a, str>, range: std::ops::Range<usize>, offset: usize) {
+        let mut label_parts = self.label.take().unwrap_or(LinkLines::new());
+        let offset_range = (offset + range.start)..(offset + range.end);
+        label_parts.push((label, offset_range));
+        self.label = Some(label_parts);
+    }
+
+    fn set_url(
+        &mut self,
+        destination: LinkDestination<'a>,
+        range: std::ops::Range<usize>,
+        offset: usize,
+    ) {
+        let offset_range = (offset + range.start)..(offset + range.end);
+        self.destination = Some((destination, offset_range));
+    }
+
+    fn set_title(
+        &mut self,
+        kind: TitleMarker,
+        value: Cow<'a, str>,
+        range: std::ops::Range<usize>,
+        offset: usize,
+    ) {
+        let offset_range = (offset + range.start)..(offset + range.end);
+        if let Some(title) = self.title.as_mut() {
+            title.push((value, offset_range))
+        } else {
+            let title = LinkTitle::new(kind, (value, offset_range));
+            self.title = Some(title);
+        }
+    }
+
+    fn has_title(&self) -> bool {
+        self.title.is_some()
+    }
+
+    fn remove_false_title(&mut self) {
+        tracing::trace!("Removing False Title");
+        self.title = None;
+    }
+
+    fn build(self) -> Option<LinkReferenceDefinition<'a>> {
+        Some(LinkReferenceDefinition {
+            label: self.label?,
+            destination: self.destination?,
+            title: self.title,
+        })
+    }
+}
+
+/// [Link Reference Definition]
+///
+/// For example, here's a reference defintion.
+/// ```markdown
+/// [label]: /destination "title"
+/// ```
+/// [link reference definition]: https://spec.commonmark.org/0.31.2/#link-reference-definition
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct LinkReferenceDefinition<'a> {
+    label: LinkLines<'a>,
+    destination: (LinkDestination<'a>, std::ops::Range<usize>),
+    title: Option<LinkTitle<'a>>,
+}
+
+impl<'a> LinkReferenceDefinition<'a> {
+    pub(super) fn range(&self) -> std::ops::Range<usize> {
+        let start = self.label.range().expect("we have a label").start;
+        let end = if let Some(title) = self.title.as_ref() {
+            title.range().expect("we have a title").end
+        } else {
+            self.destination.1.end
+        };
+        start..end
+    }
+
+    pub(super) fn write<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+        write!(writer, "[")?;
+        self.label.write(writer)?;
+        write!(writer, "]: ")?;
+        self.destination.0.write(writer)?;
+        if let Some(title) = self.title.as_ref() {
+            write!(writer, " ")?;
+            title.write(writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// [Link Destination]
+///
+/// [link destination]: https://spec.commonmark.org/0.31.2/#link-destination
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum LinkDestination<'a> {
+    /// A link destination with brackets e.g. <some/url/>
+    Bracketed(Cow<'a, str>),
+    /// A nonempty sequence of characters
+    Regular(Cow<'a, str>),
+}
+
+impl<'a> LinkDestination<'a> {
+    fn write<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+        match self {
+            Self::Bracketed(text) => write!(writer, "<{text}>"),
+            Self::Regular(text) => write!(writer, "{text}"),
+        }
+    }
+}
+
+/// [Link Title]
+///
+/// [link title]: https://spec.commonmark.org/0.31.2/#link-title
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct LinkTitle<'a> {
+    kind: TitleMarker,
+    value: LinkLines<'a>,
+}
+
+impl<'a> LinkTitle<'a> {
+    fn new(kind: TitleMarker, value: (Cow<'a, str>, std::ops::Range<usize>)) -> Self {
+        Self {
+            kind,
+            value: LinkLines::from(value),
+        }
+    }
+
+    fn push(&mut self, value: (Cow<'a, str>, std::ops::Range<usize>)) {
+        self.value.push(value)
+    }
+
+    fn range(&self) -> Option<std::ops::Range<usize>> {
+        self.value.range()
+    }
+
+    fn write<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+        write!(writer, "{}", self.kind.opener())?;
+        self.value.write(writer)?;
+        write!(writer, "{}", self.kind.closer())
+    }
+}
+
+/// Marker use to wrap the link title
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(super) enum TitleMarker {
+    /// Double quoted title like `"title"`
+    DoubleQuote,
+    /// Single quoted title like `'title'`
+    SingleQuote,
+    /// Title wrapped in Parentheses like `(title)`
+    Parentheses,
+}
+
+impl TitleMarker {
+    fn opener(&self) -> char {
+        match &self {
+            Self::DoubleQuote => '"',
+            Self::SingleQuote => '\'',
+            Self::Parentheses => '(',
+        }
+    }
+
+    fn closer(&self) -> char {
+        match &self {
+            Self::DoubleQuote => '"',
+            Self::SingleQuote => '\'',
+            Self::Parentheses => ')',
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(super) struct InvalidTitleMarker(char);
+
+impl TryFrom<char> for TitleMarker {
+    type Error = InvalidTitleMarker;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            '\'' => Ok(TitleMarker::SingleQuote),
+            '"' => Ok(TitleMarker::DoubleQuote),
+            '(' => Ok(TitleMarker::Parentheses),
+            _ => Err(InvalidTitleMarker(value)),
+        }
+    }
+}
+
+/// Collection of snippets that make up a reference link definition
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct LinkLines<'a>(Vec<(Cow<'a, str>, std::ops::Range<usize>)>);
+
+impl<'a> LinkLines<'a> {
+    fn new() -> Self {
+        LinkLines(Vec::new())
+    }
+
+    fn range(&self) -> Option<std::ops::Range<usize>> {
+        let (_, first) = self.0.first()?;
+        let (_, last) = self.0.last()?;
+        Some(first.start..last.end)
+    }
+
+    fn push(&mut self, value: (Cow<'a, str>, std::ops::Range<usize>)) {
+        self.0.push(value)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|(item, _)| item.as_ref())
+    }
+
+    fn write<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+        let mut buffer = String::new();
+        // FIXME(ytmimi) probably should provide an option to allow multi-line lines.
+        // right now everything gets formatted on a single line.
+        let mut iter = self.iter().peekable();
+        while let Some(text) = iter.next().map(|t| t.trim()) {
+            if text.is_empty() {
+                continue;
+            }
+
+            let is_last = iter.peek().is_none();
+            if !is_last {
+                write!(buffer, "{text} ")?;
+            } else {
+                write!(buffer, "{text}")?;
+            }
+        }
+        write!(writer, "{}", buffer.trim())
+    }
+}
+
+impl<'a> From<(Cow<'a, str>, std::ops::Range<usize>)> for LinkLines<'a> {
+    fn from(value: (Cow<'a, str>, std::ops::Range<usize>)) -> Self {
+        LinkLines(vec![(value)])
+    }
+}
+
+impl<'a> From<(&'static str, std::ops::Range<usize>)> for LinkLines<'a> {
+    fn from(value: (&'static str, std::ops::Range<usize>)) -> Self {
+        LinkLines(vec![(Cow::from(value.0), value.1)])
+    }
+}
+
+impl<'a> From<Vec<(Cow<'a, str>, std::ops::Range<usize>)>> for LinkLines<'a> {
+    fn from(value: Vec<(Cow<'a, str>, std::ops::Range<usize>)>) -> Self {
+        LinkLines(value)
+    }
+}
+
+pub fn parse_link_reference_definitions(
+    input: &str,
+    mut offset: usize,
+) -> Vec<LinkReferenceDefinition> {
+    let mut refernce_definitions = vec![];
+    let mut input = input;
+
+    while let Some((def, idx)) = parse_link_reference_definition(input, offset) {
+        refernce_definitions.push(def);
+        offset += idx;
+        input = &input[idx..];
+    }
+    refernce_definitions
+}
+
+/// What part of the link reference definition are we currently trying to parse
+#[derive(Debug)]
+enum LinkParserPhase {
+    /// Find the opening `[` in the label
+    FindOpeningBracket,
+    /// Parse the label inside the brackets `[]`
+    Label,
+    /// Find the colon after the label
+    Colon,
+    /// Find the start of the URL
+    UrlStart,
+    /// Find the url after the colon
+    Url(char),
+    /// Find the start of the title
+    TitleStart,
+    /// Find the optional title after the Url
+    Title(TitleMarker),
+    /// Eat indentation characters after a newline
+    HandleNewline(MultiLinePhase),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MultiLinePhase {
+    Label,
+    Title(TitleMarker),
+}
+
+/// Parse a single reference definition from
+fn parse_link_reference_definition(
+    input: &str,
+    offset: usize,
+) -> Option<(LinkReferenceDefinition, usize)> {
+    let mut phase = LinkParserPhase::FindOpeningBracket;
+    let mut builder = LinkReferenceDefinitionBuilder::new();
+    let mut start = 0;
+    let mut parsed_until = 0;
+    let mut newline_count = 0;
+    let mut is_escaped: bool = false;
+
+    let mut iter = input.char_indices().peekable();
+
+    // Too clever? Is there a simpler way to do this that I'm not realizing?
+    let is_char_esacped = |c: char, prev_escape_char: bool| -> bool {
+        // By applying the `xor` + `and` operation we get the following truth table.
+        // This helps us determine if we're escaping an escape character (\\), or
+        // if we're escaping a meaningful char liks `\]`, which esacapes the closing
+        // bracket for a label.
+        //
+        // `\]`  == escaped
+        // `\\]` != escaped
+        //
+        // | prev_escape_char (A) | is_escape_char (B) | A xor B (C)  | C && B |
+        // | -------------------- | ------------------ | ------------ | ------ |
+        // | true                 | true               | false        | false  |
+        // | false                | true               | true         | true   |
+        // | true                 | false              | true         | false  |
+        // | false                | false              | false        | false  |
+        let is_escape_char = c == '\\';
+        (prev_escape_char ^ is_escape_char) && is_escape_char
+    };
+
+    while let Some((idx, c)) = iter.next() {
+        tracing::trace!("c: {c:?}, phase: {phase:?} is_escaped: {is_escaped}");
+        match phase {
+            LinkParserPhase::FindOpeningBracket => {
+                if c != '[' {
+                    continue;
+                }
+                start = iter.peek().map(|(idx, _)| *idx)?;
+                tracing::trace!("Transition to LinkParserPhase::Label");
+                phase = LinkParserPhase::Label;
+            }
+            LinkParserPhase::Label => {
+                if c == '\n' {
+                    let label = Cow::from(&input[start..idx]);
+                    builder.set_label(label, start..idx, offset);
+                    // Handle the newline if the next char doesn't immediatly terminate the label
+                    if iter.peek().is_some_and(|(_, c)| *c != ']') {
+                        tracing::trace!(
+                            "Transition to LinkParserPhase::HandleNewline(MultiLinePhase::Label)"
+                        );
+                        phase = LinkParserPhase::HandleNewline(MultiLinePhase::Label);
+                    }
+                    start = iter.peek().map(|(idx, _)| *idx)?;
+                    continue;
+                }
+                if c != ']' || is_escaped {
+                    is_escaped = is_char_esacped(c, is_escaped);
+                    continue;
+                }
+                let label = Cow::from(&input[start..idx]);
+                builder.set_label(label, start..idx, offset);
+                tracing::trace!("Transition to LinkParserPhase::Colon");
+                phase = LinkParserPhase::Colon;
+                parsed_until = idx;
+                is_escaped = false;
+            }
+            LinkParserPhase::Colon => {
+                if c != ':' {
+                    continue;
+                }
+                tracing::trace!("Transition to LinkParserPhase::UrlStart");
+                phase = LinkParserPhase::UrlStart;
+                parsed_until = idx;
+            }
+            LinkParserPhase::HandleNewline(next_phase) => {
+                let next_is_important = match (next_phase, iter.peek()) {
+                    (MultiLinePhase::Label, Some((_, ']'))) => true,
+                    (MultiLinePhase::Title(marker), Some((_, c))) => {
+                        *c == marker.opener() || *c == marker.closer()
+                    }
+                    _ => false,
+                };
+                // FIXME(ytmimi) Assuming that `>` indicates a blockquote, but maybe there's a
+                // chance that its part of the title or label
+                if !next_is_important && (c.is_whitespace() || c == '>') {
+                    continue;
+                }
+                start = idx;
+                match next_phase {
+                    MultiLinePhase::Label => {
+                        tracing::trace!("Transition to LinkParserPhase::Label");
+                        phase = LinkParserPhase::Label
+                    }
+                    MultiLinePhase::Title(marker) => {
+                        tracing::trace!("Transition to LinkParserPhase::Title(marker)");
+                        phase = LinkParserPhase::Title(marker)
+                    }
+                }
+            }
+            LinkParserPhase::UrlStart => {
+                // TODO(ytmimi) handle newlines in label. If we're in a nested context like
+                // a block quote, then we need to potentially ignore leading `>` chars.
+                //
+                // For now, just assume we can eat all chars until we reach the start of the URL
+                if c.is_whitespace() || c == '>' {
+                    continue;
+                }
+
+                // We're at the start of the URL
+                start = idx;
+                tracing::trace!("Transition to LinkParserPhase::Url(c)");
+                phase = LinkParserPhase::Url(c);
+                parsed_until = idx;
+            }
+            LinkParserPhase::Url(start_char) => {
+                // Taking a look at the [link destination spec], I don't think we can have newlines
+                // within the destination.
+                // [link destination spec]: https://spec.commonmark.org/0.30/#link-destination
+                match start_char {
+                    '<' => {
+                        if c != '>' || is_escaped {
+                            is_escaped = is_char_esacped(c, is_escaped);
+                            continue;
+                        }
+
+                        let url = Cow::from(&input[start + 1..idx]);
+                        builder.set_url(LinkDestination::Bracketed(url), start..idx, offset);
+                        tracing::trace!("Transition to LinkParserPhase::TitleStart");
+                        phase = LinkParserPhase::TitleStart;
+                        parsed_until = idx;
+                    }
+                    _ => {
+                        if !c.is_whitespace() {
+                            let is_last = iter.peek().is_none();
+                            if is_last {
+                                let url = Cow::from(&input[start..=idx]);
+                                builder.set_url(LinkDestination::Regular(url), start..idx, offset);
+                                break;
+                            }
+                            continue;
+                        }
+
+                        if c == '\n' {
+                            newline_count += 1;
+                        }
+
+                        let url = Cow::from(&input[start..idx]);
+                        builder.set_url(LinkDestination::Regular(url), start..idx, offset);
+                        tracing::trace!("Transition to LinkParserPhase::TitleStart");
+                        phase = LinkParserPhase::TitleStart;
+                        parsed_until = idx;
+                    }
+                }
+            }
+            LinkParserPhase::TitleStart => {
+                if c == '\n' {
+                    newline_count += 1;
+                    if newline_count > 1 {
+                        // There can only be one newline between the end of the URL and the
+                        // start of the title
+                        parsed_until = idx;
+                        break;
+                    }
+                }
+
+                if c.is_whitespace() || c == '>' {
+                    continue;
+                }
+
+                match TitleMarker::try_from(c) {
+                    Ok(marker) => {
+                        start = iter.peek().map(|(idx, _)| *idx)?;
+                        tracing::trace!("Transition to LinkParserPhase::Title(marker)");
+                        phase = LinkParserPhase::Title(marker);
+                        parsed_until = idx;
+                    }
+                    Err(_) => {
+                        // If we don't have a title opener then this isn't a title
+                        parsed_until = idx;
+                        break;
+                    }
+                }
+            }
+            LinkParserPhase::Title(marker) => {
+                if c == '\n' {
+                    let label = Cow::from(&input[start..idx]);
+                    builder.set_title(marker, label, start..idx, offset);
+                    // Handle the newline if the next char doesn't immediatly terminate the title
+                    if iter.peek().is_some_and(|(_, c)| *c != marker.closer()) {
+                        tracing::trace!(
+                            "Transition to LinkParserPhase::HandleNewline(MultiLinePhase::Title)"
+                        );
+                        phase = LinkParserPhase::HandleNewline(MultiLinePhase::Title(marker));
+                    }
+                    start = iter.peek().map(|(idx, _)| *idx)?;
+                    continue;
+                }
+                if c != marker.closer() || is_escaped {
+                    is_escaped = is_char_esacped(c, is_escaped);
+                    continue;
+                }
+
+                let title = Cow::from(&input[start..idx]);
+                builder.set_title(marker, title, start..idx, offset);
+                parsed_until = idx;
+                tracing::trace!("Done Parsing Link Definition");
+                break;
+            }
+        }
+    }
+
+    // Titles can't be followed by any non whitespace chars on their line
+    if builder.has_title() {
+        // Check if there are any non-whitespace characters that come after the title
+        for (idx, c) in iter {
+            if c == '\n' {
+                // We only need to check up to the newline
+                // +1 so that we start after the newline. Also, +1 is fine since '\n' is ascii
+                parsed_until = idx + 1;
+                break;
+            }
+
+            if !c.is_whitespace() {
+                builder.remove_false_title();
+                parsed_until = idx;
+                break;
+            }
+        }
+    }
+
+    builder.build().map(|def| (def, parsed_until))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn cmp_single_line(rhs: LinkLines<'_>, line: &str) -> bool {
+        if rhs.0.len() > 1 {
+            return false;
+        }
+
+        matches!(rhs.0.first(), Some((l, _)) if l == line)
+    }
+
+    macro_rules! check_parsed_link_reference_definition {
+        (definition:$definition:literal, label:$label:literal, url:$url:expr,) => {
+            check_parsed_link_reference_definition! {
+                check
+                definition: $definition,
+                label: $label,
+                url: $url,
+                title: Option::<&str>::None,
+            }
+        };
+        (
+            definition:$definition:literal,
+            label:$label:literal,
+            url:$url:expr,
+            title:$title:expr,
+        ) => {
+            check_parsed_link_reference_definition! {
+                check
+                definition: $definition,
+                label: $label,
+                url: $url,
+                title: Some($title),
+            }
+        };
+        (
+            check
+            definition:$definition:literal,
+            label:$label:literal,
+            url:$url:expr,
+            title:$title:expr,
+        ) => {
+            let result = parse_link_reference_definition($definition, 0).unwrap().0;
+            assert!(cmp_single_line(result.label, $label));
+            assert_eq!(result.destination.0, $url);
+            if $title.is_some() {
+                assert!(cmp_single_line(
+                    result.title.unwrap().value,
+                    $title.unwrap()
+                ));
+            } else {
+                assert!(result.title.is_none());
+            }
+        };
+    }
+
+    #[test]
+    fn test_parse_link_reference_definition() {
+        check_parsed_link_reference_definition! {
+            definition: "[foo-one]: foo-url 'single-quote-title'",
+            label: "foo-one",
+            url: LinkDestination::Regular("foo-url".into()),
+            title: "single-quote-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[foo-two]: <foo-url> 'single-quote-title'",
+            label: "foo-two",
+            url: LinkDestination::Bracketed("foo-url".into()),
+            title: "single-quote-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[foo-three]: no-title",
+            label: "foo-three",
+            url: LinkDestination::Regular(Cow::from("no-title")),
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: r#"[bar-one]: bar-url "double-quote-title""#,
+            label: "bar-one",
+            url: LinkDestination::Regular("bar-url".into()),
+            title: "double-quote-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: r#"[bar-two]: <bar-url> "double-quote-title""#,
+            label: "bar-two",
+            url: LinkDestination::Bracketed("bar-url".into()),
+            title: "double-quote-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: r#"[bar-three]: no-title"#,
+            label: "bar-three",
+            url: LinkDestination::Regular("no-title".into()),
+        }
+
+        check_parsed_link_reference_definition! {
+            definition:  "[baz-one]: baz-url (paren-title)",
+            label: "baz-one",
+            url: LinkDestination::Regular("baz-url".into()),
+            title: "paren-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[baz-two]: <baz-url> (paren-title)",
+            label: "baz-two",
+            url: LinkDestination::Bracketed("baz-url".into()),
+            title: "paren-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[baz-three]: no-title",
+            label: "baz-three",
+            url: LinkDestination::Regular("no-title".into()),
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[empty-url]: <> 'single-quote-title'",
+            label: "empty-url",
+            url: LinkDestination::Bracketed("".into()),
+            title: "single-quote-title",
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[empty-url]: <> 'single-quote-title' <- not a title bc of this extra text",
+            label: "empty-url",
+            url: LinkDestination::Bracketed("".into()),
+        }
+    }
+
+    #[test]
+    fn test_parse_multiple_link_reference_definitions() {
+        let definition = r#"
+[foo]: /foo
+[bar]: /bar (title)
+[baz]: /baz ''
+"#;
+        let result = parse_link_reference_definitions(definition, 0);
+        let expected = vec![
+            LinkReferenceDefinition {
+                label: ("foo", 2..5).into(),
+                destination: (LinkDestination::Regular("/foo".into()), 8..12),
+                title: None,
+            },
+            LinkReferenceDefinition {
+                label: ("bar", 14..17).into(),
+                destination: (LinkDestination::Regular("/bar".into()), 20..24),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::Parentheses,
+                    value: ("title", 26..31).into(),
+                }),
+            },
+            LinkReferenceDefinition {
+                label: ("baz", 34..37).into(),
+                destination: (LinkDestination::Regular("/baz".into()), 40..44),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::SingleQuote,
+                    value: ("", 46..46).into(),
+                }),
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_multi_line_link_reference_definitions() {
+        let definition = r#"
+[foo]:
+   /foo
+[bar]:
+   /bar
+   (title)
+[baz]:
+   /baz
+   ''
+"#;
+
+        let result = parse_link_reference_definitions(definition, 0);
+        let expected = vec![
+            LinkReferenceDefinition {
+                label: ("foo", 2..5).into(),
+                destination: (LinkDestination::Regular("/foo".into()), 11..15),
+                title: None,
+            },
+            LinkReferenceDefinition {
+                label: ("bar", 17..20).into(),
+                destination: (LinkDestination::Regular("/bar".into()), 26..30),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::Parentheses,
+                    value: ("title", 35..40).into(),
+                }),
+            },
+            LinkReferenceDefinition {
+                label: ("baz", 43..46).into(),
+                destination: (LinkDestination::Regular("/baz".into()), 52..56),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::SingleQuote,
+                    value: ("", 61..61).into(),
+                }),
+            },
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_nested_multi_line_link_reference_definitions() {
+        let definition = r#">
+>[foo]:
+>   /foo
+"#;
+
+        let result = parse_link_reference_definitions(definition, 0);
+        let expected = vec![LinkReferenceDefinition {
+            label: ("foo", 4..7).into(),
+            destination: (LinkDestination::Regular("/foo".into()), 14..18),
+            title: None,
+        }];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn with_multi_line_label() {
+        let definition = r#"
+[foo
+ bar
+]:
+   /foo-bar
+[
+    oof
+    rab
+]: /oof-rab
+"this is a title"
+"#;
+
+        let result = parse_link_reference_definitions(definition, 0);
+        #[rustfmt::skip]
+        let expected = vec![
+            LinkReferenceDefinition {
+                label: vec![
+                    (Cow::from("foo"), 2..5),
+                    (Cow::from("bar"), 7..10),
+                    (Cow::from(""), 11..11),
+                ].into(),
+                destination: (LinkDestination::Regular("/foo-bar".into()), 17..25),
+                title: None,
+            },
+            LinkReferenceDefinition {
+                label: vec![
+                    (Cow::from(""), 27..27),
+                    (Cow::from("oof"), 32..35),
+                    (Cow::from("rab"), 40..43),
+                    (Cow::from(""), 44..44),
+                ].into(),
+                destination: (LinkDestination::Regular("/oof-rab".into()), 47..55),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::DoubleQuote,
+                    value: (Cow::from("this is a title"), 57..72).into()
+                }),
+            }
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn with_multi_line_title() {
+        let definition = r#"[fizz-buzz]: <fizz-buzz>
+"
+this
+is a
+ multi-line
+title
+"
+"#;
+
+        let result = parse_link_reference_definitions(definition, 0);
+        #[rustfmt::skip]
+        let expected = vec![
+            LinkReferenceDefinition {
+                label: ("fizz-buzz", 1..10).into(),
+                destination: (LinkDestination::Bracketed("fizz-buzz".into()), 13..23),
+                title: Some(LinkTitle {
+                    kind: TitleMarker::DoubleQuote,
+                    value: vec![
+                        (Cow::from(""), 26..26),
+                        (Cow::from("this"), 27..31),
+                        (Cow::from("is a"), 32..36),
+                        (Cow::from("multi-line"), 38..48),
+                        (Cow::from("title"), 49..54),
+                        (Cow::from(""), 55..55),
+                    ].into()
+                }),
+            }
+        ];
+        assert_eq!(result, expected);
+    }
+}

--- a/src/links.rs
+++ b/src/links.rs
@@ -146,18 +146,6 @@ fn link_title_start(link: &[u8]) -> usize {
     0
 }
 
-/// Grab the link destination from the source text
-///
-/// `pulldown_cmark` unescape link destinations and titles so grabbing the escaped link
-/// from the source is the easiest way to maintain all the escaped characters.
-pub(super) fn recover_escaped_link_destination_and_title(
-    complete_link: &str,
-    has_title: bool,
-) -> Option<(String, Option<(String, char)>)> {
-    let rest = complete_link.split_once(':').map(|(_, rest)| rest.trim())?;
-    split_inline_url_from_title(rest, has_title)
-}
-
 fn trim_angle_brackes(url: &str) -> &str {
     if url.starts_with('<') && url.ends_with('>') {
         url[1..url.len() - 1].trim()

--- a/src/list.rs
+++ b/src/list.rs
@@ -79,6 +79,10 @@ impl ListMarker {
             Self::Unordered(_) => 2,
         }
     }
+
+    pub(super) fn len(&self) -> usize {
+        self.indentation_len() - 1
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -103,6 +103,7 @@ fn idempotence_test() {
 
         if formatted_input != input {
             errors += 1;
+            eprintln!("error formatting {}", file.display());
         }
     }
 

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -1667,20 +1667,17 @@ fn markdown_link_reference_definitions_195() {
 [Foo bar]"##);
 }
 
+// relaxed testing with the `test` macro because we normalize the title text
 #[test]
 fn markdown_link_reference_definitions_196() {
     // https://spec.commonmark.org/0.30/#example-196
-    test_identical_markdown_events!(r##"[foo]: /url '
+    test!(r##"[foo]: /url '
 title
 line1
 line2
 '
 
-[foo]"##,r##"[foo]: /url '
-title
-line1
-line2
-'
+[foo]"##,r##"[foo]: /url 'title line1 line2'
 
 [foo]"##);
 }
@@ -1756,9 +1753,7 @@ fn markdown_link_reference_definitions_204() {
     test_identical_markdown_events!(r##"[foo]
 
 [foo]: first
-[foo]: second"##,r##"[foo]
-
-[foo]: first"##);
+[foo]: second"##);
 }
 
 #[test]
@@ -1801,7 +1796,6 @@ fn markdown_link_reference_definitions_209() {
     test_identical_markdown_events!(r##"[foo]: /url "title" ok"##);
 }
 
-// FIXME(ytmim) the "title" is duplcated here
 #[test]
 fn markdown_link_reference_definitions_210() {
     // https://spec.commonmark.org/0.30/#example-210
@@ -1885,10 +1879,7 @@ fn markdown_link_reference_definitions_218() {
     // https://spec.commonmark.org/0.30/#example-218
     test!(r##"[foo]
 
-> [foo]: /url"##,r##"[foo]
-
->
-[foo]: /url"##);
+> [foo]: /url"##);
 }
 
 #[test]
@@ -2841,10 +2832,6 @@ fn markdown_lists_317() {
 - b
 
   [ref]: /url
-- d"##,r##"- a
-- b
-
-[ref]: /url
 - d"##);
 }
 
@@ -4301,10 +4288,6 @@ fn markdown_links_543() {
     test!(r##"[foo]: /url1
 
 [foo]: /url2
-
-[bar][foo]"##,r##"[foo]: /url1
-
-
 
 [bar][foo]"##);
 }

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1435,20 +1435,17 @@ fn gfm_markdown_link_reference_definitions_164() {
 [Foo bar]"##);
 }
 
+// relaxed testing with the `test` macro because we normalize the title text
 #[test]
 fn gfm_markdown_link_reference_definitions_165() {
     // https://github.github.com/gfm/#example-165
-    test_identical_markdown_events!(r##"[foo]: /url '
+    test!(r##"[foo]: /url '
 title
 line1
 line2
 '
 
-[foo]"##,r##"[foo]: /url '
-title
-line1
-line2
-'
+[foo]"##,r##"[foo]: /url 'title line1 line2'
 
 [foo]"##);
 }
@@ -1524,9 +1521,7 @@ fn gfm_markdown_link_reference_definitions_173() {
     test_identical_markdown_events!(r##"[foo]
 
 [foo]: first
-[foo]: second"##,r##"[foo]
-
-[foo]: first"##);
+[foo]: second"##);
 }
 
 #[test]
@@ -1571,7 +1566,6 @@ fn gfm_markdown_link_reference_definitions_178() {
     test_identical_markdown_events!(r##"[foo]: /url "title" ok"##);
 }
 
-// FIXME(ytmim) the "title" is duplcated here
 #[test]
 fn gfm_markdown_link_reference_definitions_179() {
     // https://github.github.com/gfm/#example-179
@@ -1658,10 +1652,7 @@ fn gfm_markdown_link_reference_definitions_187() {
     // https://github.github.com/gfm/#example-187
     test!(r##"[foo]
 
-> [foo]: /url"##,r##"[foo]
-
->
-[foo]: /url"##);
+> [foo]: /url"##);
 }
 
 #[test]
@@ -2715,10 +2706,6 @@ fn gfm_markdown_lists_297() {
 - b
 
   [ref]: /url
-- d"##,r##"- a
-- b
-
-[ref]: /url
 - d"##);
 }
 
@@ -4373,10 +4360,6 @@ fn gfm_markdown_links_552() {
     test_identical_markdown_events!(r##"[foo]: /url1
 
 [foo]: /url2
-
-[bar][foo]"##,r##"[foo]: /url1
-
-
 
 [bar][foo]"##);
 }

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -1636,7 +1636,9 @@
   },
   {
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
-    "formattedMarkdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]",
+    "formattedMarkdown": "[foo]: /url 'title line1 line2'\n\n[foo]",
+    "testMacro": "test",
+    "comment": "relaxed testing with the `test` macro because we normalize the title text",
     "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
     "example": 196,
     "start_line": 3225,
@@ -1704,7 +1706,6 @@
   },
   {
     "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
-    "formattedMarkdown": "[foo]\n\n[foo]: first",
     "html": "<p><a href=\"first\">foo</a></p>\n",
     "example": 204,
     "start_line": 3330,
@@ -1820,7 +1821,6 @@
   },
   {
     "markdown": "[foo]\n\n> [foo]: /url\n",
-    "formattedMarkdown": "[foo]\n\n>\n[foo]: /url",
     "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
     "example": 218,
     "start_line": 3507,
@@ -2663,7 +2663,6 @@
   },
   {
     "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
-    "formattedMarkdown": "- a\n- b\n\n[ref]: /url\n- d",
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
     "example": 317,
     "start_line": 5645,
@@ -4487,7 +4486,6 @@
   },
   {
     "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
-    "formattedMarkdown": "[foo]: /url1\n\n\n\n[bar][foo]",
     "html": "<p><a href=\"/url1\">bar</a></p>\n",
     "example": 543,
     "start_line": 8193,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -1535,7 +1535,9 @@
   },
   {
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
-    "formattedMarkdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]",
+    "formattedMarkdown": "[foo]: /url 'title line1 line2'\n\n[foo]",
+    "testMacro": "test",
+    "comment": "relaxed testing with the `test` macro because we normalize the title text",
     "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
     "example": 165,
     "start_line": 2871,
@@ -1611,7 +1613,6 @@
   },
   {
     "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
-    "formattedMarkdown": "[foo]\n\n[foo]: first",
     "html": "<p><a href=\"first\">foo</a></p>\n",
     "example": 173,
     "start_line": 2976,
@@ -1743,7 +1744,6 @@
   },
   {
     "markdown": "[foo]\n\n> [foo]: /url\n",
-    "formattedMarkdown": "[foo]\n\n>\n[foo]: /url",
     "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
     "example": 187,
     "start_line": 3150,
@@ -2807,7 +2807,6 @@
   },
   {
     "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
-    "formattedMarkdown": "- a\n- b\n\n[ref]: /url\n- d",
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
     "example": 297,
     "start_line": 5564,
@@ -5114,7 +5113,6 @@
   },
   {
     "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
-    "formattedMarkdown": "[foo]: /url1\n\n\n\n[bar][foo]",
     "html": "<p><a href=\"/url1\">bar</a></p>\n",
     "example": 552,
     "start_line": 8453,

--- a/tests/target/reference_link_definitions.md
+++ b/tests/target/reference_link_definitions.md
@@ -1,0 +1,47 @@
+# reference definition at the start of a block quote
+> [one]: /one-url "one-title"
+>
+> [one]
+>
+>
+
+# reference definition at the end of a block quote
+>
+> [two]
+>
+> [two]: /two-url "two-title"
+>
+
+# reference definition at the start of a list item
+* [three]: /three-url "three-title"
+  [three]
+
+
+# reference definition at the end of a list item
+* [four]
+
+  [four]: /four-url "four-title"
+
+
+# reference definition in block quote, but link outside
+> [five]: /five-url "five-title"
+[five]
+
+[six]
+> [six]: /six-url "six-title"
+
+
+# reference definition in list item, but link outside
+- [seven]: /seven-url "seven-title"
+[seven]
+
+[eight]
+- [eight]: /eight-url "eight-title"
+
+# duplicate reference definitions
+[nine]
+[nine]: /nine-first-url "nine-first-title"
+[nine]: /nine-second-url "nine-second-title"
+
+# reference definition without a link
+[ten]: /ten-url "ten-url"

--- a/tests/target/reference_link_definitions.md
+++ b/tests/target/reference_link_definitions.md
@@ -1,3 +1,5 @@
+[zero]: /zero-url "zero-title"
+
 # reference definition at the start of a block quote
 > [one]: /one-url "one-title"
 >
@@ -35,8 +37,16 @@
 - [seven]: /seven-url "seven-title"
 [seven]
 
+1.
+   [seven-point-one]: /seven-point-one-url "seven-point-one-title"
+[seve-point-one]
+
 [eight]
 - [eight]: /eight-url "eight-title"
+
+[eight-point-one]
+1.
+   [eight-point-one]: /eight-point-one-url "eight-point-one-title"
 
 # duplicate reference definitions
 [nine]
@@ -45,3 +55,39 @@
 
 # reference definition without a link
 [ten]: /ten-url "ten-url"
+
+# Deeply nested reference definitions
+>
+> [eleven]: /eleven-url
+>
+>>
+>> [twelve]: </twelve-url> (twelve-title)
+>>
+>>
+>>> [thirteen] </thirteen-url> 'thirteen-title'
+>>>
+>>>> [eleven]
+>>>> [twelve]
+>>>> [thirteen]
+
+> * [fourteen]
+>   >
+>   > [fourteen]: fourteen-url 'fourteen-title'
+>   > *
+>   > *
+>   >   *
+>   >   * [fifteen]: /fifteen-url (fifteen-title)
+>   >     + [fifteen]
+
+# I tried defining the reference in a table. I don't think it works
+| col 1     | col 2 |
+| --------- | ----- |
+| [sixteen] |       |
+|           |       |
+
+[sixteen]: /sixteen-url 'sixteen-title'
+
+# emojis!
+[7️⃣-teen]
+
+[7️⃣]: 7️⃣-teen-url '7️⃣-teen-title'


### PR DESCRIPTION
I've been hacking away at improving how [link reference definitions](https://github.github.com/gfm/#link-reference-definition) are handled. It's a very large change, and although I think there's room for improvement, I'm happy that these definitions are handled better now!

In order to recover all definitions I've implemented a parser so now the project isn't reliant on `pulldown_cmark` to grab these definitions.