### PR TITLE
Remove some uses of the `test!` macro and document the rest

### DIFF
--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -353,6 +353,7 @@ fn markdown_thematic_breaks_48() {
     test_identical_markdown_events!(r##"    ***"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn markdown_thematic_breaks_49() {
     // https://spec.commonmark.org/0.30/#example-49
@@ -996,7 +997,7 @@ fn markdown_fenced_code_blocks_126() {
 #[test]
 fn markdown_fenced_code_blocks_127() {
     // https://spec.commonmark.org/0.30/#example-127
-    test!(r##"`````
+    test_identical_markdown_events!(r##"`````
 
 ```
 aaa"##,r##"`````
@@ -1045,6 +1046,7 @@ aaa
 ```"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn markdown_fenced_code_blocks_132() {
     // https://spec.commonmark.org/0.30/#example-132
@@ -1059,6 +1061,7 @@ aaa
 ```"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn markdown_fenced_code_blocks_133() {
     // https://spec.commonmark.org/0.30/#example-133
@@ -1104,7 +1107,7 @@ aaa
 #[test]
 fn markdown_fenced_code_blocks_137() {
     // https://spec.commonmark.org/0.30/#example-137
-    test!(r##"```
+    test_identical_markdown_events!(r##"```
 aaa
     ```"##,r##"```
 aaa
@@ -1122,7 +1125,7 @@ aaa"##);
 #[test]
 fn markdown_fenced_code_blocks_139() {
     // https://spec.commonmark.org/0.30/#example-139
-    test!(r##"~~~~~~
+    test_identical_markdown_events!(r##"~~~~~~
 aaa
 ~~~ ~~"##,r##"~~~~~~
 aaa
@@ -1667,7 +1670,7 @@ fn markdown_link_reference_definitions_195() {
 [Foo bar]"##);
 }
 
-// relaxed testing with the `test` macro because we normalize the title text
+// relaxed testing with the `test!` macro because we normalize the title text
 #[test]
 fn markdown_link_reference_definitions_196() {
     // https://spec.commonmark.org/0.30/#example-196
@@ -1877,7 +1880,7 @@ fn markdown_link_reference_definitions_217() {
 #[test]
 fn markdown_link_reference_definitions_218() {
     // https://spec.commonmark.org/0.30/#example-218
-    test!(r##"[foo]
+    test_identical_markdown_events!(r##"[foo]
 
 > [foo]: /url"##);
 }
@@ -2211,6 +2214,7 @@ fn markdown_list_items_256() {
   two"##);
 }
 
+// Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed
 #[test]
 fn markdown_list_items_257() {
     // https://spec.commonmark.org/0.30/#example-257
@@ -2781,6 +2785,7 @@ fn markdown_lists_312() {
   \- e"##);
 }
 
+// Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed
 #[test]
 fn markdown_lists_313() {
     // https://spec.commonmark.org/0.30/#example-313
@@ -2828,7 +2833,7 @@ fn markdown_lists_316() {
 #[test]
 fn markdown_lists_317() {
     // https://spec.commonmark.org/0.30/#example-317
-    test!(r##"- a
+    test_identical_markdown_events!(r##"- a
 - b
 
   [ref]: /url
@@ -2838,7 +2843,7 @@ fn markdown_lists_317() {
 #[test]
 fn markdown_lists_318() {
     // https://spec.commonmark.org/0.30/#example-318
-    test!(r##"- a
+    test_identical_markdown_events!(r##"- a
 - ```
   b
 
@@ -4019,6 +4024,7 @@ fn markdown_links_505() {
     test_identical_markdown_events!(r##"[link](/url "title \"&quot;")"##);
 }
 
+// Using the `test!` macro because the formatted Markdown Events are different
 #[test]
 fn markdown_links_506() {
     // https://spec.commonmark.org/0.30/#example-506
@@ -4285,7 +4291,7 @@ fn markdown_links_542() {
 #[test]
 fn markdown_links_543() {
     // https://spec.commonmark.org/0.30/#example-543
-    test!(r##"[foo]: /url1
+    test_identical_markdown_events!(r##"[foo]: /url1
 
 [foo]: /url2
 

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -135,6 +135,7 @@ fn gfm_markdown_thematic_breaks_18() {
     test_identical_markdown_events!(r##"    ***"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn gfm_markdown_thematic_breaks_19() {
     // https://github.github.com/gfm/#example-19
@@ -827,6 +828,7 @@ aaa
 ```"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn gfm_markdown_fenced_code_blocks_102() {
     // https://github.github.com/gfm/#example-102
@@ -841,6 +843,7 @@ aaa
 ```"##);
 }
 
+// Using the `test!` macro because the number of Text Events are different
 #[test]
 fn gfm_markdown_fenced_code_blocks_103() {
     // https://github.github.com/gfm/#example-103
@@ -1435,7 +1438,7 @@ fn gfm_markdown_link_reference_definitions_164() {
 [Foo bar]"##);
 }
 
-// relaxed testing with the `test` macro because we normalize the title text
+// relaxed testing with the `test!` macro because we normalize the title text
 #[test]
 fn gfm_markdown_link_reference_definitions_165() {
     // https://github.github.com/gfm/#example-165
@@ -1650,7 +1653,7 @@ fn gfm_markdown_link_reference_definitions_186() {
 #[test]
 fn gfm_markdown_link_reference_definitions_187() {
     // https://github.github.com/gfm/#example-187
-    test!(r##"[foo]
+    test_identical_markdown_events!(r##"[foo]
 
 > [foo]: /url"##);
 }
@@ -2072,6 +2075,7 @@ fn gfm_markdown_list_items_234() {
   two"##);
 }
 
+// Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed
 #[test]
 fn gfm_markdown_list_items_235() {
     // https://github.github.com/gfm/#example-235
@@ -2655,6 +2659,7 @@ fn gfm_markdown_lists_292() {
   \- e"##);
 }
 
+// Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed
 #[test]
 fn gfm_markdown_lists_293() {
     // https://github.github.com/gfm/#example-293
@@ -2702,7 +2707,7 @@ fn gfm_markdown_lists_296() {
 #[test]
 fn gfm_markdown_lists_297() {
     // https://github.github.com/gfm/#example-297
-    test!(r##"- a
+    test_identical_markdown_events!(r##"- a
 - b
 
   [ref]: /url
@@ -4093,6 +4098,7 @@ fn gfm_markdown_links_514() {
     test_identical_markdown_events!(r##"[link](/url "title \"&quot;")"##);
 }
 
+// Using the `test!` macro because the formatted Markdown Events are different
 #[test]
 fn gfm_markdown_links_515() {
     // https://github.github.com/gfm/#example-515

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -414,7 +414,8 @@
     "start_line": 943,
     "end_line": 949,
     "section": "Thematic breaks",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different"
   },
   {
     "markdown": "_____________________________________\n",
@@ -1065,8 +1066,7 @@
     "example": 127,
     "start_line": 2082,
     "end_line": 2092,
-    "section": "Fenced code blocks",
-    "testMacro": "test"
+    "section": "Fenced code blocks"
   },
   {
     "markdown": "> ```\n> aaa\n\nbbb\n",
@@ -1111,7 +1111,8 @@
     "start_line": 2149,
     "end_line": 2160,
     "section": "Fenced code blocks",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different"
   },
   {
     "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
@@ -1121,7 +1122,8 @@
     "start_line": 2163,
     "end_line": 2174,
     "section": "Fenced code blocks",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different"
   },
   {
     "markdown": "    ```\n    aaa\n    ```\n",
@@ -1156,8 +1158,7 @@
     "example": 137,
     "start_line": 2216,
     "end_line": 2224,
-    "section": "Fenced code blocks",
-    "testMacro": "test"
+    "section": "Fenced code blocks"
   },
   {
     "markdown": "``` ```\naaa\n",
@@ -1174,8 +1175,7 @@
     "example": 139,
     "start_line": 2239,
     "end_line": 2247,
-    "section": "Fenced code blocks",
-    "testMacro": "test"
+    "section": "Fenced code blocks"
   },
   {
     "markdown": "foo\n```\nbar\n```\nbaz\n",
@@ -1638,7 +1638,7 @@
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
     "formattedMarkdown": "[foo]: /url 'title line1 line2'\n\n[foo]",
     "testMacro": "test",
-    "comment": "relaxed testing with the `test` macro because we normalize the title text",
+    "comment": "relaxed testing with the `test!` macro because we normalize the title text",
     "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
     "example": 196,
     "start_line": 3225,
@@ -1825,8 +1825,7 @@
     "example": 218,
     "start_line": 3507,
     "end_line": 3515,
-    "section": "Link reference definitions",
-    "testMacro": "test"
+    "section": "Link reference definitions"
   },
   {
     "markdown": "aaa\n\nbbb\n",
@@ -2159,7 +2158,8 @@
     "start_line": 4220,
     "end_line": 4230,
     "section": "List items",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed"
   },
   {
     "markdown": " -    one\n\n      two\n",
@@ -2635,7 +2635,8 @@
     "start_line": 5556,
     "end_line": 5573,
     "section": "Lists",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed"
   },
   {
     "markdown": "- a\n- b\n\n- c\n",
@@ -2667,8 +2668,7 @@
     "example": 317,
     "start_line": 5645,
     "end_line": 5663,
-    "section": "Lists",
-    "testMacro":"test"
+    "section": "Lists"
   },
   {
     "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
@@ -2677,8 +2677,7 @@
     "example": 318,
     "start_line": 5668,
     "end_line": 5687,
-    "section": "Lists",
-    "testMacro": "test"
+    "section": "Lists"
   },
   {
     "markdown": "- a\n  - b\n\n    c\n- d\n",
@@ -4191,7 +4190,8 @@
     "start_line": 7765,
     "end_line": 7769,
     "section": "Links",
-    "testMacro": "test"
+    "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown Events are different"
   },
   {
     "markdown": "[link](/url \"title \"and\" title\")\n",
@@ -4490,8 +4490,7 @@
     "example": 543,
     "start_line": 8193,
     "end_line": 8201,
-    "section": "Links",
-    "testMacro": "test"
+    "section": "Links"
   },
   {
     "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -180,6 +180,7 @@
     "end_line": 620,
     "section": "Thematic breaks",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different",
     "extensions": []
   },
   {
@@ -959,6 +960,7 @@
     "end_line": 1828,
     "section": "Fenced code blocks",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different",
     "extensions": []
   },
   {
@@ -970,6 +972,7 @@
     "end_line": 1842,
     "section": "Fenced code blocks",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the number of Text Events are different",
     "extensions": []
   },
   {
@@ -1537,7 +1540,7 @@
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
     "formattedMarkdown": "[foo]: /url 'title line1 line2'\n\n[foo]",
     "testMacro": "test",
-    "comment": "relaxed testing with the `test` macro because we normalize the title text",
+    "comment": "relaxed testing with the `test!` macro because we normalize the title text",
     "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
     "example": 165,
     "start_line": 2871,
@@ -1749,7 +1752,6 @@
     "start_line": 3150,
     "end_line": 3158,
     "section": "Link reference definitions",
-    "testMacro": "test",
     "extensions": []
   },
   {
@@ -2223,6 +2225,7 @@
     "end_line": 4091,
     "section": "List items",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed",
     "extensions": []
   },
   {
@@ -2776,6 +2779,7 @@
     "end_line": 5492,
     "section": "Lists",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown includes comments to prevent the code block from being absorbed",
     "extensions": []
   },
   {
@@ -2812,7 +2816,6 @@
     "start_line": 5564,
     "end_line": 5582,
     "section": "Lists",
-    "testMacro": "test",
     "extensions": []
   },
   {
@@ -4783,6 +4786,7 @@
     "end_line": 8030,
     "section": "Links",
     "testMacro": "test",
+    "comment": "Using the `test!` macro because the formatted Markdown Events are different",
     "extensions": []
   },
   {


### PR DESCRIPTION
The `test!` macro is a relaxed version of the
`test_identical_markdown_events!` macro that only checks if the formatted markdown is generated as expected. There are a few cases where pulldown cmark parses different events after formatting, but luckily those seem to be rare.