### PR TITLE
rename `FormatterBuilder` -> `FormatBuilder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ let output = rewrite_markdown(markdown).unwrap();
 assert_eq!(output, expected);
 ```
 
-If you need more control over markdown formatting you can use the `FormatterBuilder` and the
+If you need more control over markdown formatting you can use the `FormatBuilder` and the
 `rewrite_markdown_with_builder` function.
 
 
 ```rust
-use markdown_fmt::{FormatterBuilder, rewrite_markdown_with_builder};
+use markdown_fmt::{FormatBuilder, rewrite_markdown_with_builder};
 
 let markdown = r##"# The standard Lorem Ipsum passage, used since the 1500s
 
@@ -62,7 +62,7 @@ sunt in culpa qui officia deserunt mollit anim id
 est laborum."
 "##;
 
-let mut builder = FormatterBuilder::default();
+let mut builder = FormatBuilder::default();
 builder.max_width(Some(50));
 
 let output = rewrite_markdown_with_builder(markdown, builder).unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,21 +3,21 @@ use crate::config::Config;
 pub(crate) type CodeBlockFormatter = Box<dyn Fn(&str, String) -> String>;
 
 /// Builder for the [MarkdownFormatter](crate::MarkdownFormatter)
-pub struct FormatterBuilder {
+pub struct FormatBuilder {
     code_block_formatter: CodeBlockFormatter,
     config: Config,
 }
 
-impl FormatterBuilder {
-    /// Create a [FormatterBuilder] with a custom code block formatter.
+impl FormatBuilder {
+    /// Create a [FormatBuilder] with a custom code block formatter.
     ///
     /// The closure used to reformat code blocks takes two arguments;
     /// the [`info string`] and the complete code snippet
     ///
     /// ```rust
     /// # use markdown_fmt::MarkdownFormatter;
-    /// # use markdown_fmt::FormatterBuilder;
-    /// let builder = FormatterBuilder::with_code_block_formatter(|info_string, code_block| {
+    /// # use markdown_fmt::FormatBuilder;
+    /// let builder = FormatBuilder::with_code_block_formatter(|info_string, code_block| {
     ///     // Set the code block formatting logic
     ///     match info_string.to_lowercase().as_str() {
     ///         "rust" => {
@@ -43,15 +43,15 @@ impl FormatterBuilder {
     ///
     /// ```rust
     /// # use markdown_fmt::MarkdownFormatter;
-    /// # use markdown_fmt::FormatterBuilder;
-    /// let builder = FormatterBuilder::default();
+    /// # use markdown_fmt::FormatBuilder;
+    /// let builder = FormatBuilder::default();
     /// let formatter: MarkdownFormatter = builder.build();
     /// ```
     pub fn build(self) -> crate::MarkdownFormatter {
         crate::MarkdownFormatter::new(self.code_block_formatter, self.config)
     }
 
-    /// Configure how code blocks should be reformatted after creating the [FormatterBuilder].
+    /// Configure how code blocks should be reformatted after creating the [FormatBuilder].
     ///
     /// The closure passed to `code_block_formatter` takes two arguments;
     /// the [`info string`] and the complete code snippet
@@ -81,9 +81,9 @@ impl FormatterBuilder {
     }
 }
 
-impl std::fmt::Debug for FormatterBuilder {
+impl std::fmt::Debug for FormatBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FormatterBuilder")
+        write!(f, "FormatBuilder")
     }
 }
 
@@ -92,9 +92,9 @@ fn default_code_block_formatter(_info_str: &str, code_block: String) -> String {
     code_block
 }
 
-impl Default for FormatterBuilder {
+impl Default for FormatBuilder {
     fn default() -> Self {
-        FormatterBuilder {
+        FormatBuilder {
             code_block_formatter: Box::new(default_code_block_formatter),
             config: Config::default(),
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -17,9 +17,9 @@ use crate::table::TableState;
 
 /// Used to format Markdown inputs.
 ///
-/// To get a [MarkdownFormatter] use [FormatterBuilder::build]
+/// To get a [MarkdownFormatter] use [FormatBuilder::build]
 ///
-/// [FormatterBuilder::build]: crate::FormatterBuilder::build
+/// [FormatBuilder::build]: crate::FormatBuilder::build
 pub struct MarkdownFormatter {
     code_block_formatter: CodeBlockFormatter,
     config: Config,
@@ -29,8 +29,8 @@ impl MarkdownFormatter {
     /// Format Markdown input
     ///
     /// ```rust
-    /// # use markdown_fmt::FormatterBuilder;
-    /// let builder = FormatterBuilder::default();
+    /// # use markdown_fmt::FormatBuilder;
+    /// let builder = FormatBuilder::default();
     /// let formatter = builder.build();
     /// let input = "   #  Header! ";
     /// let rewrite = formatter.format(input).unwrap();
@@ -55,10 +55,10 @@ impl MarkdownFormatter {
 
     /// Helper method to easily initiazlie the [MarkdownFormatter].
     ///
-    /// This is marked as `pub(crate)` because users are expected to use the [FormatterBuilder]
+    /// This is marked as `pub(crate)` because users are expected to use the [FormatBuilder]
     /// When creating a [MarkdownFormatter].
     ///
-    /// [FormatterBuilder]: crate::FormatterBuilder
+    /// [FormatBuilder]: crate::FormatBuilder
     pub(crate) fn new(code_block_formatter: CodeBlockFormatter, config: Config) -> Self {
         Self {
             code_block_formatter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@
 //! # Ok::<(), std::fmt::Error>(())
 //! ```
 //!
-//! # Using the [Builder](builder::FormatterBuilder)
+//! # Using the [Builder](builder::FormatBuilder)
 //!
 //! The builder gives you more control to configure Markdown formatting.
 //!
 //! ````rust
-//! use markdown_fmt::{rewrite_markdown, rewrite_markdown_with_builder, FormatterBuilder};
+//! use markdown_fmt::{rewrite_markdown, rewrite_markdown_with_builder, FormatBuilder};
 //!
-//! let builder = FormatterBuilder::with_code_block_formatter(|info_string, code_block| {
+//! let builder = FormatBuilder::with_code_block_formatter(|info_string, code_block| {
 //!     match info_string.to_lowercase().as_str() {
 //!         "markdown" => rewrite_markdown(&code_block).unwrap_or(code_block),
 //!         _ => code_block
@@ -78,7 +78,7 @@ mod table;
 mod test;
 mod utils;
 
-pub use builder::FormatterBuilder;
+pub use builder::FormatBuilder;
 pub use formatter::MarkdownFormatter;
 
 // Used for doctests in the README
@@ -110,13 +110,13 @@ struct ReadMe;
 /// assert_eq!(output, formatted_markdown);
 /// ```
 pub fn rewrite_markdown(input: &str) -> Result<String, std::fmt::Error> {
-    rewrite_markdown_with_builder(input, FormatterBuilder::default())
+    rewrite_markdown_with_builder(input, FormatBuilder::default())
 }
 
 /// Reformat a markdown snippet with user specified settings
 ///
 /// ```rust
-/// # use markdown_fmt::{rewrite_markdown_with_builder, FormatterBuilder};
+/// # use markdown_fmt::{rewrite_markdown_with_builder, FormatBuilder};
 /// let markdown = r##"  #   Learn Rust Checklist!
 /// 1. Read [The Book]
 ///  2.  Watch tutorials
@@ -133,13 +133,13 @@ pub fn rewrite_markdown(input: &str) -> Result<String, std::fmt::Error> {
 /// [The Book]: https://doc.rust-lang.org/book/
 /// "##;
 ///
-/// let builder = FormatterBuilder::default();
+/// let builder = FormatBuilder::default();
 /// let output = rewrite_markdown_with_builder(markdown, builder).unwrap();
 /// assert_eq!(output, formatted_markdown);
 /// ```
 pub fn rewrite_markdown_with_builder(
     input: &str,
-    builder: FormatterBuilder,
+    builder: FormatBuilder,
 ) -> Result<String, std::fmt::Error> {
     let formatter = builder.build();
     formatter.format(input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use clap::Parser;
-use markdown_fmt::{rewrite_markdown_with_builder, FormatterBuilder};
+use markdown_fmt::{rewrite_markdown_with_builder, FormatBuilder};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -41,7 +41,7 @@ fn main() -> Result<(), anyhow::Error> {
     match cli.input.extension().and_then(OsStr::to_str) {
         Some("md") => {
             let input = fs::read_to_string(&cli.input)?;
-            let mut builder = FormatterBuilder::default();
+            let mut builder = FormatBuilder::default();
             builder.max_width(cli.max_width);
             let result = rewrite_markdown_with_builder(&input, builder)?;
             output_result(&cli.input, &result, cli.stdout)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,9 @@
 use crate::config::Config;
-use crate::{rewrite_markdown, rewrite_markdown_with_builder, FormatterBuilder};
+use crate::{rewrite_markdown, rewrite_markdown_with_builder, FormatBuilder};
 use rust_search::SearchBuilder;
 use std::path::{Path, PathBuf};
 
-impl FormatterBuilder {
+impl FormatBuilder {
     pub fn from_leading_config_comments(input: &str) -> Self {
         let mut config = Config::default();
 
@@ -22,7 +22,7 @@ impl FormatterBuilder {
             config.set(config_option, value.trim());
         }
 
-        let mut builder = FormatterBuilder::default();
+        let mut builder = FormatBuilder::default();
         builder.config(config);
         builder
     }
@@ -75,7 +75,7 @@ fn check_markdown_formatting() {
 
     for file in get_test_files("tests/source", "md") {
         let input = std::fs::read_to_string(&file).unwrap();
-        let builder = FormatterBuilder::from_leading_config_comments(&input);
+        let builder = FormatBuilder::from_leading_config_comments(&input);
         let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();
         let target_file = file
             .strip_prefix("tests/source")
@@ -98,7 +98,7 @@ fn idempotence_test() {
 
     for file in get_test_files("tests/target", "md") {
         let input = std::fs::read_to_string(&file).unwrap();
-        let builder = FormatterBuilder::from_leading_config_comments(&input);
+        let builder = FormatBuilder::from_leading_config_comments(&input);
         let formatted_input = rewrite_markdown_with_builder(&input, builder).unwrap();
 
         if formatted_input != input {


### PR DESCRIPTION
`FormatterBuilder` seemed a little clunky to me.