### PR TITLE
Recursive Markdown formatting

### DIFF
--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -297,9 +297,9 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::Config;
     use crate::formatter::FormatState;
     use crate::test::get_test_files;
+    use crate::FormatBuilder;
     use std::borrow::Cow;
     use std::path::PathBuf;
 
@@ -449,7 +449,9 @@ mod test {
             let adapted_events = pulldown_cmark::Parser::new_ext(markdown, options)
                 .into_offset_iter()
                 .all_loose_lists();
-            let fmt_state = FormatState::new(markdown, Config::default(), |_, s| s, adapted_events);
+
+            let formatter = FormatBuilder::default().build();
+            let fmt_state = FormatState::new(markdown, &formatter, adapted_events);
 
             let output = fmt_state.format().unwrap();
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -2,7 +2,7 @@ use super::formatter::FormatState;
 
 const ATX_HEADER_ESCAPES: [&str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
 
-impl<'i, F, I> FormatState<'i, F, I>
+impl<I> FormatState<'_, '_, I>
 where
     I: Iterator,
 {

--- a/src/links.rs
+++ b/src/links.rs
@@ -3,7 +3,7 @@ use pulldown_cmark::Event;
 use std::borrow::Cow;
 use std::fmt::Write;
 
-impl<'i, F, I> FormatState<'i, F, I>
+impl<'i, I> FormatState<'i, '_, I>
 where
     I: Iterator<Item = (Event<'i>, std::ops::Range<usize>)>,
 {

--- a/tests/source/recursive_markdown_formatting.md
+++ b/tests/source/recursive_markdown_formatting.md
@@ -1,0 +1,28 @@
+<!-- :max_width:60 -->
+
+# Recursive Markdown Formatting
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+~~~~~markdown
+
+## Nested x 1
+
+>
+  > This is the first level of nesting
+  >
+  >
+
+* ~~~~markdown
+
+  ### Nested x 2
+
+  | col 1 | col 2 |
+  | ----- | ----- |
+  | second level | of   |
+  |           | nesting |
+
+  * > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  ~~~~
+
+~~~~~

--- a/tests/target/recursive_markdown_formatting.md
+++ b/tests/target/recursive_markdown_formatting.md
@@ -1,0 +1,29 @@
+<!-- :max_width:60 -->
+
+# Recursive Markdown Formatting
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+do eiusmod tempor incididunt ut labore et dolore magna
+aliqua.
+
+~~~~~markdown
+## Nested x 1
+
+>
+> This is the first level of nesting
+>
+>
+
+* ~~~~markdown
+  ### Nested x 2
+
+  | col 1        | col 2   |
+  | ------------ | ------- |
+  | second level | of      |
+  |              | nesting |
+
+  * > Lorem ipsum dolor sit amet, consectetur adipiscing
+    > elit, sed do eiusmod tempor incididunt ut labore et
+    > dolore magna aliqua.
+  ~~~~
+~~~~~


### PR DESCRIPTION
Now when we encounter a nested markdown code block that has `markdown` in the info string we'll also format that using our markdown formatter. Prior to this, we'd only format top level markdown.