### PR TITLE
Add `CodeBlockContext` to code block formatter closure 

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -9,7 +9,7 @@ use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel};
 use pulldown_cmark::{LinkType, Options, Parser, Tag};
 
 use crate::adapters::LooseListExt;
-use crate::builder::CodeBlockFormatter;
+use crate::builder::{CodeBlockContext, CodeBlockFormatter};
 use crate::config::Config;
 use crate::links::{parse_link_reference_definitions, LinkReferenceDefinition};
 use crate::list::ListMarker;
@@ -487,8 +487,12 @@ where
                 .format(&code_block_buffer)
                 .unwrap_or(code_block_buffer)
         } else {
+            let ctx = CodeBlockContext {
+                indentation,
+                max_width: current_max_width,
+            };
             // Call the code_block_formatter fn
-            (self.formatter.code_block_formatter)(info_string, code_block_buffer)
+            (self.formatter.code_block_formatter)(&ctx, info_string, code_block_buffer)
         };
 
         // restore the width after formatting the code block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! ````rust
 //! use markdown_fmt::{rewrite_markdown, rewrite_markdown_with_builder, FormatBuilder};
 //!
-//! let builder = FormatBuilder::with_code_block_formatter(|info_string, code_block| {
+//! let builder = FormatBuilder::with_code_block_formatter(|_ctx, info_string, code_block| {
 //!     match info_string.to_lowercase().as_str() {
 //!         "markdown" => rewrite_markdown(&code_block).unwrap_or(code_block),
 //!         _ => code_block
@@ -78,7 +78,7 @@ mod table;
 mod test;
 mod utils;
 
-pub use builder::FormatBuilder;
+pub use builder::{CodeBlockContext, FormatBuilder};
 pub use formatter::MarkdownFormatter;
 
 // Used for doctests in the README


### PR DESCRIPTION
The context provides info to help custom formatters correctly format the context of code blocks within the bounds configured on the `FormatBuilder`. For example, it provides access to the indentation and `max_width` available to the code block. Of course custom formatters can choose to ignore this information, but it's there if needed.

Edit: currently based on https://github.com/ytmimi/markdown-fmt/pull/36. That PR should be merged first.