### PR TITLE
Add option to explicitly reflow text 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ est laborum."
 "##;
 
 let mut builder = FormatBuilder::default();
-builder.max_width(Some(50));
+builder.max_width(Some(50)).reflow_text(true);
 
 let output = rewrite_markdown_with_builder(markdown, builder).unwrap();
 assert_eq!(output, expected);

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ builder.code_block_formatter(|_ctx, info_str, code_block| {
         "text" => code_block.to_uppercase(),
         _ => code_block
     }
-
 });
 
 let output = rewrite_markdown_with_builder(markdown, builder).unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -109,11 +109,74 @@ impl FormatBuilder {
         self
     }
 
-    /// Configure the max with when rewriting paragraphs.
+    /// Configure the max width when rewriting paragraphs.
     ///
     /// When set to [None], the deafault, paragraph width is left unchanged.
+    ///
+    /// # Setting [`max_width`](Self::max_width) to [None] (default)
+    ///
+    /// ```rust
+    /// # use markdown_fmt::FormatBuilder;
+    /// let mut builder = FormatBuilder::default();
+    /// builder.max_width(None);
+    ///
+    /// let input = "this text should not wrap";
+    /// let output = builder.build().format(input).unwrap();
+    /// assert_eq!(output, input)
+    /// ```
+    /// ---
+    /// # Setting [`max_width`](Self::max_width) to `20`
+    /// ```rust
+    /// # use markdown_fmt::FormatBuilder;
+    /// let mut builder = FormatBuilder::default();
+    /// builder.max_width(Some(20));
+    ///
+    /// let input = "this text should definetly wrap";
+    ///
+    /// let expected = "this text should
+    /// definetly wrap";
+    /// let output = builder.build().format(input).unwrap();
+    /// assert_eq!(output, expected)
+    /// ```
     pub fn max_width(&mut self, max_width: Option<usize>) -> &mut Self {
         self.config.set_max_width(max_width);
+        self
+    }
+
+    /// Configure whether or not paragraph text should reflow when `max_width`
+    /// is also configured. By default text will not reflow.
+    ///
+    /// # Setting [`reflow_text`](Self::reflow_text) to `false` (default)
+    /// ```rust
+    /// # use markdown_fmt::FormatBuilder;
+    /// let mut builder = FormatBuilder::default();
+    /// builder.max_width(Some(30)).reflow_text(false);
+    ///
+    /// let input = "this
+    /// will not
+    /// reflow";
+    ///
+    /// let output = builder.build().format(input).unwrap();
+    /// assert_eq!(output, input)
+    /// ```
+    /// ---
+    /// # Setting [`reflow_text`](Self::reflow_text) to `true`
+    /// ```rust
+    /// # use markdown_fmt::FormatBuilder;
+    /// let mut builder = FormatBuilder::default();
+    /// builder.max_width(Some(30)).reflow_text(true);
+    ///
+    /// let input = "this
+    /// text
+    /// should
+    /// reflow";
+    ///
+    /// let expected = "this text should reflow";
+    /// let output = builder.build().format(input).unwrap();
+    /// assert_eq!(output, expected)
+    /// ```
+    pub fn reflow_text(&mut self, should_reflow: bool) -> &mut Self {
+        self.config.set_reflow_text(should_reflow);
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Default)]
 pub(crate) struct Config {
     max_width: Option<usize>,
+    reflow_text: bool,
 }
 
 impl Config {
@@ -12,6 +13,14 @@ impl Config {
         self.max_width = value;
     }
 
+    pub(crate) fn reflow_text(&self) -> bool {
+        self.reflow_text
+    }
+
+    pub(crate) fn set_reflow_text(&mut self, value: bool) {
+        self.reflow_text = value;
+    }
+
     /// Internal setter for config options. Used for testing
     #[cfg(test)]
     pub(crate) fn set(&mut self, field: &str, value: &str) {
@@ -19,6 +28,10 @@ impl Config {
             "max_width" => {
                 let value = value.parse::<usize>().unwrap();
                 self.max_width = Some(value)
+            }
+            "reflow_text" => {
+                let value = value.parse::<bool>().unwrap();
+                self.reflow_text = value;
             }
             _ => panic!("unknown configuration {field}"),
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -671,11 +671,13 @@ where
                 }
                 self.nested_context.push(tag);
                 let capacity = (range.end - range.start) * 2;
-                let width = self
-                    .formatter
-                    .get_config(|c| c.max_width())
-                    .map(|w| w.saturating_sub(self.indentation_len()));
-                self.paragraph = Some(Paragraph::new(width, capacity));
+                let (max_width, should_reflow_text) = self.formatter.get_config(|c| {
+                    let width = c
+                        .max_width()
+                        .map(|w| w.saturating_sub(self.indentation_len()));
+                    (width, c.reflow_text())
+                });
+                self.paragraph = Some(Paragraph::new(max_width, should_reflow_text, capacity));
             }
             Tag::Heading(level, _, _) => {
                 if self.needs_indent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ struct Cli {
     /// The max width to use when reformatting paragraphs.
     #[arg(short, long)]
     max_width: Option<usize>,
+    /// Should text reflow when max width is also configured.
+    #[arg(short, long)]
+    reflow_text: bool,
 }
 
 fn output_result(input: &Path, result: &str, stdout: bool) -> Result<(), anyhow::Error> {
@@ -42,7 +45,9 @@ fn main() -> Result<(), anyhow::Error> {
         Some("md") => {
             let input = fs::read_to_string(&cli.input)?;
             let mut builder = FormatBuilder::default();
-            builder.max_width(cli.max_width);
+            builder
+                .max_width(cli.max_width)
+                .reflow_text(cli.reflow_text);
             let result = rewrite_markdown_with_builder(&input, builder)?;
             output_result(&cli.input, &result, cli.stdout)
         }

--- a/tests/source/config/reflow_text/true_with_max_width.md
+++ b/tests/source/config/reflow_text/true_with_max_width.md
@@ -1,0 +1,7 @@
+<!-- :max_width:50 -->
+<!-- :reflow_text:true -->
+
+this
+text
+will
+reflow

--- a/tests/target/config/reflow_text/false.md
+++ b/tests/target/config/reflow_text/false.md
@@ -1,0 +1,8 @@
+<!-- :max_width:50 -->
+<!-- :reflow_text:false -->
+
+This text will
+not
+reflow.
+Would need to explicity set
+`reflow_text=true` for that to happen

--- a/tests/target/config/reflow_text/true_with_max_width.md
+++ b/tests/target/config/reflow_text/true_with_max_width.md
@@ -1,0 +1,4 @@
+<!-- :max_width:50 -->
+<!-- :reflow_text:true -->
+
+this text will reflow

--- a/tests/target/config/reflow_text/true_without_max_width.md
+++ b/tests/target/config/reflow_text/true_without_max_width.md
@@ -1,0 +1,9 @@
+<!-- :reflow_text:true -->
+
+this
+text
+will not reflow because we don't know
+how we should reflow it. `reflow_text`
+only
+kicks in when
+`max_width` is also set.


### PR DESCRIPTION
Previously paragraph text was implicitly reflowed when `max_width` was configured, but I'd like to make that a more explicit choice so users have more control over the formatting.