### PR TITLE
add doc comment and `![allow(missing_docs]]` to fix ci

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -82,13 +82,12 @@ fn write_test_cases<W>(
 where
     W: std::io::Write,
 {
-    write!(writer, "// @generated\n")?;
-    write!(writer, "// generated running `cargo build -F gen-tests`\n")?;
-    write!(
-        writer,
-        "// test macros are defined in tests/common/mod.rs\n"
-    )?;
-    write!(writer, "mod common;\n")?;
+    writeln!(writer, "// @generated")?;
+    writeln!(writer, "// generated running `cargo build -F gen-tests`")?;
+    writeln!(writer, "// test macros are defined in tests/common/mod.rs")?;
+    // #![allow(missing_docs)] to work around missing_doc issue on nightly
+    writeln!(writer, "#![allow(missing_docs)]")?;
+    writeln!(writer, "mod common;")?;
 
     for test_case in test_cases.into_iter() {
         write_test_case(writer, prefix, test_case, url)?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,14 @@ use rust_search::SearchBuilder;
 use std::path::{Path, PathBuf};
 
 impl FormatBuilder {
+    /// Configure the FormatBuilder using leading comments in test files.
+    ///
+    /// For example:
+    /// ```markdown
+    /// <!-- :max_width:50 -->
+    ///
+    /// Paragraphs will now wrap at a column width of 50.
+    /// ```
     pub fn from_leading_config_comments(input: &str) -> Self {
         let mut config = Config::default();
 

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -1,6 +1,7 @@
 // @generated
 // generated running `cargo build -F gen-tests`
 // test macros are defined in tests/common/mod.rs
+#![allow(missing_docs)]
 mod common;
 
 #[test]

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1,6 +1,7 @@
 // @generated
 // generated running `cargo build -F gen-tests`
 // test macros are defined in tests/common/mod.rs
+#![allow(missing_docs)]
 mod common;
 
 #[test]


### PR DESCRIPTION
Trying to build tests with a recent nightly compiler in CI broke and started complaining about on `pub` method not being documented because we've configured `missing-docs = "deny"` in the Cargo.toml.

Additionally the compiler complained  about missing docs on integration tests so I'm silencing those errors with `![allow(missing_docs]]`.

Also realized I could use `writeln!` to simplify the `build.rs`.