### PR TITLE
bump pulldown-cmark to  v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,6 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
@@ -275,7 +269,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "libc",
 ]
 
@@ -367,11 +361,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "memchr",
  "unicase",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ missing-docs = "deny"
 
 [dependencies]
 itertools = "0.10"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { version = "0.10.3", default-features = false }
 unicode-width = "0.1"
 unicode-segmentation = "1.9"
 clap = { version = "4.5.2", features = ["derive"], optional = true }

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -4398,7 +4398,10 @@ fn markdown_links_554() {
 #[test]
 fn markdown_links_555() {
     // https://spec.commonmark.org/0.30/#example-555
-    test_identical_markdown_events!("[foo] \n[]\n\n[foo]: /url \"title\"");
+    test_identical_markdown_events!("[foo] \n[]\n\n[foo]: /url \"title\"",r##"[foo]
+[]
+
+[foo]: /url "title""##);
 }
 
 #[test]
@@ -4639,7 +4642,10 @@ fn markdown_images_585() {
 #[test]
 fn markdown_images_586() {
     // https://spec.commonmark.org/0.30/#example-586
-    test_identical_markdown_events!("![foo] \n[]\n\n[foo]: /url \"title\"");
+    test_identical_markdown_events!("![foo] \n[]\n\n[foo]: /url \"title\"",r##"![foo]
+[]
+
+[foo]: /url "title""##);
 }
 
 #[test]
@@ -5044,7 +5050,8 @@ baz"##);
 #[test]
 fn markdown_soft_line_breaks_649() {
     // https://spec.commonmark.org/0.30/#example-649
-    test_identical_markdown_events!("foo \n baz","foo \nbaz");
+    test_identical_markdown_events!("foo \n baz",r##"foo
+baz"##);
 }
 
 #[test]

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -4468,7 +4468,10 @@ fn gfm_markdown_links_563() {
 #[test]
 fn gfm_markdown_links_564() {
     // https://github.github.com/gfm/#example-564
-    test_identical_markdown_events!("[foo] \n[]\n\n[foo]: /url \"title\"");
+    test_identical_markdown_events!("[foo] \n[]\n\n[foo]: /url \"title\"",r##"[foo]
+[]
+
+[foo]: /url "title""##);
 }
 
 #[test]
@@ -4703,7 +4706,10 @@ fn gfm_markdown_images_594() {
 #[test]
 fn gfm_markdown_images_595() {
     // https://github.github.com/gfm/#example-595
-    test_identical_markdown_events!("![foo] \n[]\n\n[foo]: /url \"title\"");
+    test_identical_markdown_events!("![foo] \n[]\n\n[foo]: /url \"title\"",r##"![foo]
+[]
+
+[foo]: /url "title""##);
 }
 
 #[test]
@@ -5198,7 +5204,8 @@ baz"##);
 #[test]
 fn gfm_markdown_soft_line_breaks_669() {
     // https://github.github.com/gfm/#example-669
-    test_identical_markdown_events!("foo \n baz","foo \nbaz");
+    test_identical_markdown_events!("foo \n baz",r##"foo
+baz"##);
 }
 
 #[test]

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -4584,6 +4584,7 @@
   },
   {
     "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "formattedMarkdown": "[foo]\n[]\n\n[foo]: /url \"title\"",
     "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
     "example": 555,
     "start_line": 8339,
@@ -4837,6 +4838,7 @@
   },
   {
     "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "formattedMarkdown":"![foo]\n[]\n\n[foo]: /url \"title\"",
     "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
     "example": 586,
     "start_line": 8667,
@@ -5345,7 +5347,7 @@
   },
   {
     "markdown": "foo \n baz\n",
-    "formattedMarkdown": "foo \nbaz",
+    "formattedMarkdown": "foo\nbaz",
     "html": "<p>foo\nbaz</p>\n",
     "example": 649,
     "start_line": 9375,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -5226,6 +5226,7 @@
   },
   {
     "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "formattedMarkdown": "[foo]\n[]\n\n[foo]: /url \"title\"",
     "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
     "example": 564,
     "start_line": 8598,
@@ -5507,6 +5508,7 @@
   },
   {
     "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "formattedMarkdown": "![foo]\n[]\n\n[foo]: /url \"title\"",
     "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
     "example": 595,
     "start_line": 8926,
@@ -6201,7 +6203,7 @@
   },
   {
     "markdown": "foo \n baz\n",
-    "formattedMarkdown": "foo \nbaz",
+    "formattedMarkdown": "foo\nbaz",
     "html": "<p>foo\nbaz</p>\n",
     "example": 669,
     "start_line": 9832,

--- a/tests/target/reference_link_definitions.md
+++ b/tests/target/reference_link_definitions.md
@@ -27,6 +27,7 @@
 
 # reference definition in block quote, but link outside
 > [five]: /five-url "five-title"
+
 [five]
 
 [six]
@@ -35,16 +36,19 @@
 
 # reference definition in list item, but link outside
 - [seven]: /seven-url "seven-title"
+
 [seven]
 
 1.
    [seven-point-one]: /seven-point-one-url "seven-point-one-title"
+
 [seve-point-one]
 
 [eight]
 - [eight]: /eight-url "eight-title"
 
 [eight-point-one]
+
 1.
    [eight-point-one]: /eight-point-one-url "eight-point-one-title"
 
@@ -73,6 +77,7 @@
 > * [fourteen]
 >   >
 >   > [fourteen]: fourteen-url 'fourteen-title'
+>   >
 >   > *
 >   > *
 >   >   *


### PR DESCRIPTION
Mostly Some internal changes to get the codebase to compile with the new version of `pulldown-cmark`. Because of some changes to the parser a few test cases were also changed.