### PR TITLE
Define the `pulldown_cmark` options used for parsing events in a macro

### DIFF
--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -310,8 +310,7 @@ mod test {
 
     macro_rules! check_unchanged_events {
         ($markdown:literal) => {
-            let mut options = pulldown_cmark::Options::all();
-            options.remove(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION);
+            let options = crate::pulldown_cmark_options!();
 
             let input = pulldown_cmark::Parser::new_ext($markdown, options.clone())
                 .into_offset_iter()
@@ -420,8 +419,7 @@ mod test {
             let content = std::fs::read_to_string(&file).unwrap();
             let (markdown, expected_events) = content.split_once(SEPARATOR).unwrap();
 
-            let mut options = pulldown_cmark::Options::all();
-            options.remove(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION);
+            let options = crate::pulldown_cmark_options!();
 
             let events = pulldown_cmark::Parser::new_ext(markdown, options)
                 .into_offset_iter()

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use std::str::FromStr;
 
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, TagEnd};
-use pulldown_cmark::{LinkType, Options, Parser, Tag};
+use pulldown_cmark::{LinkType, Parser, Tag};
 
 use crate::adapters::LooseListExt;
 use crate::builder::{CodeBlockContext, CodeBlockFormatter};
@@ -16,6 +16,21 @@ use crate::links::{parse_link_reference_definitions, LinkReferenceDefinition};
 use crate::list::ListMarker;
 use crate::paragraph::Paragraph;
 use crate::table::TableState;
+
+// Defined using a macro so that the parsing options can be shared with tests for consistency.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pulldown_cmark_options {
+    () => {
+        pulldown_cmark::Options::ENABLE_TABLES
+            | pulldown_cmark::Options::ENABLE_FOOTNOTES
+            | pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+            | pulldown_cmark::Options::ENABLE_TASKLISTS
+            | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES
+            | pulldown_cmark::Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS
+            | pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
+    };
+}
 
 /// Used to format Markdown inputs.
 ///
@@ -45,13 +60,7 @@ impl MarkdownFormatter {
             Some(("".into(), "".into()))
         };
 
-        let options = Options::ENABLE_TABLES
-            | Options::ENABLE_FOOTNOTES
-            | Options::ENABLE_STRIKETHROUGH
-            | Options::ENABLE_TASKLISTS
-            | Options::ENABLE_HEADING_ATTRIBUTES
-            | Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS
-            | Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
+        let options = pulldown_cmark_options!();
 
         let parser = Parser::new_with_broken_link_callback(input, options, Some(&mut callback));
         let iter = parser.into_offset_iter().all_loose_lists();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,13 +33,7 @@ macro_rules! test_identical_markdown_events {
     ($input:expr, $output:expr) => {
         let formatted = $crate::test!($input, $output);
 
-        let options = pulldown_cmark::Options::ENABLE_TABLES
-            | pulldown_cmark::Options::ENABLE_FOOTNOTES
-            | pulldown_cmark::Options::ENABLE_STRIKETHROUGH
-            | pulldown_cmark::Options::ENABLE_TASKLISTS
-            | pulldown_cmark::Options::ENABLE_HEADING_ATTRIBUTES
-            | pulldown_cmark::Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS
-            | pulldown_cmark::Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
+        let options = markdown_fmt::pulldown_cmark_options!();
 
         let input_events = pulldown_cmark::Parser::new_ext($input, options.clone()).into_iter()
                 .filter(|e| {


### PR DESCRIPTION
This makes it a lot easier to centralize the definition and reuse it in tests.