### PR TITLE
use `style_edition=2024` and update formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 error_on_line_overflow = true
 error_on_unformatted = true
 format_generated_files = false
-version = "Two"
+style_edition = "2024"
 format_code_in_doc_comments = true

--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -302,9 +302,9 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::FormatBuilder;
     use crate::formatter::FormatState;
     use crate::test::get_test_files;
-    use crate::FormatBuilder;
     use std::borrow::Cow;
     use std::path::PathBuf;
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -12,7 +12,7 @@ use crate::adapters::LooseListExt;
 use crate::builder::{CodeBlockContext, CodeBlockFormatter};
 use crate::config::Config;
 use crate::footnote::FootnoteDefinition;
-use crate::links::{parse_link_reference_definitions, LinkReferenceDefinition};
+use crate::links::{LinkReferenceDefinition, parse_link_reference_definitions};
 use crate::list::ListMarker;
 use crate::paragraph::Paragraph;
 use crate::table::TableState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 #![allow(missing_docs)]
 
 use clap::Parser;
-use markdown_fmt::{rewrite_markdown_with_builder, FormatBuilder};
+use markdown_fmt::{FormatBuilder, rewrite_markdown_with_builder};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::{rewrite_markdown, rewrite_markdown_with_builder, FormatBuilder};
+use crate::{FormatBuilder, rewrite_markdown, rewrite_markdown_with_builder};
 use rust_search::SearchBuilder;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
on nightly rustfmt, `version` was replaced by `style_edition`. This using the new style edition with nighty formatting also updates how imports are sorted.