### PR TITLE
unify the various rewrite buffers into an enum

### DIFF
--- a/src/footnote.rs
+++ b/src/footnote.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 static FOOTNOTE_INDENTATION: &str = "    ";
 
 /// A buffer where we write footnote definition text
+#[derive(Debug, PartialEq)]
 pub(crate) struct FootnoteDefinition {
     buffer: String,
     indentation: Vec<Cow<'static, str>>,

--- a/src/header.rs
+++ b/src/header.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 /// A buffer where we write the content of markdown headers
+#[derive(Debug, PartialEq)]
 pub(super) struct Header<'i> {
     buffer: String,
     indentation: Vec<Cow<'static, str>>,
@@ -272,7 +273,7 @@ impl<'i> Header<'i> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) enum HeaderKind<'i> {
     /// ATX headers like `#`, `##`, `###`, etc.
     Atx(HeadingLevel),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ mod table;
 #[cfg(test)]
 mod test;
 mod utils;
+mod writer;
 
 pub use builder::{CodeBlockContext, FormatBuilder};
 pub use formatter::MarkdownFormatter;

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -4,6 +4,7 @@ use textwrap::Options as TextWrapOptions;
 const MARKDOWN_HARD_BREAK: &str = "  \n";
 
 /// A buffer where we write text
+#[derive(Debug, PartialEq)]
 pub(super) struct Paragraph {
     buffer: String,
     max_width: Option<usize>,

--- a/src/table.rs
+++ b/src/table.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use unicode_segmentation::UnicodeSegmentation;
 
+#[derive(Debug, PartialEq)]
 pub(super) struct TableState<'a> {
     /// Alignment markers for HTML rendering
     /// * :-: center alignment

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,62 @@
+use crate::footnote::FootnoteDefinition;
+use crate::header::Header;
+use crate::paragraph::Paragraph;
+use crate::table::TableState;
+use pulldown_cmark::CodeBlockKind;
+
+#[derive(Debug, PartialEq)]
+pub(super) enum MarkdownWriter<'i> {
+    CodeBlock((String, CodeBlockKind<'i>)),
+    Header(Header<'i>),
+    FootnoteDefinition(FootnoteDefinition),
+    Paragraph(Paragraph),
+    Table(TableState<'i>),
+}
+
+impl MarkdownWriter<'_> {
+    pub(super) fn is_empty(&self) -> bool {
+        match self {
+            Self::CodeBlock((c, _)) => c.is_empty(),
+            Self::FootnoteDefinition(f) => f.is_empty(),
+            Self::Header(h) => h.is_empty(),
+            Self::Paragraph(p) => p.is_empty(),
+            Self::Table(t) => t.is_empty(),
+        }
+    }
+}
+
+impl std::fmt::Write for MarkdownWriter<'_> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        match self {
+            Self::CodeBlock((c, _)) => c.write_str(s),
+            Self::FootnoteDefinition(f) => f.write_str(s),
+            Self::Header(h) => h.write_str(s),
+            Self::Paragraph(p) => p.write_str(s),
+            Self::Table(t) => t.write_str(s),
+        }
+    }
+}
+
+impl<'i> From<Header<'i>> for MarkdownWriter<'i> {
+    fn from(value: Header<'i>) -> Self {
+        Self::Header(value)
+    }
+}
+
+impl From<FootnoteDefinition> for MarkdownWriter<'_> {
+    fn from(value: FootnoteDefinition) -> Self {
+        Self::FootnoteDefinition(value)
+    }
+}
+
+impl From<Paragraph> for MarkdownWriter<'_> {
+    fn from(value: Paragraph) -> Self {
+        Self::Paragraph(value)
+    }
+}
+
+impl<'i> From<TableState<'i>> for MarkdownWriter<'i> {
+    fn from(value: TableState<'i>) -> Self {
+        Self::Table(value)
+    }
+}


### PR DESCRIPTION
I found it a little cumbersome to add new rewrite buffers like footnote definitions and headers because I'd need to add a new field to the `FormatState` and then I'd also need to add methods to check if I was currently formatting that markdown construct. Now we simply push the `Writer` onto the stack, and we know that we should always write to that top buffer. I think this simplifies the internals.