### PR TITLE
bump `pulldown-cmark` to v0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ missing-docs = "deny"
 
 [dependencies]
 itertools = "0.10"
-pulldown-cmark = { version = "0.10.3", default-features = false }
+pulldown-cmark = { version = "0.11.3", default-features = false }
 unicode-width = "0.1"
 unicode-segmentation = "1.9"
 clap = { version = "4.5.2", features = ["derive"], optional = true }

--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -270,7 +270,7 @@ where
                             Event::Start(
                                 Tag::Heading { .. }
                                 | Tag::List(_)
-                                | Tag::BlockQuote
+                                | Tag::BlockQuote(_)
                                 | Tag::CodeBlock(_)
                                 | Tag::Table(_)
                                 | Tag::HtmlBlock

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -616,6 +616,9 @@ where
                         write!(self, "[ ] ")?;
                     }
                 }
+                Event::DisplayMath(..) | Event::InlineMath(..) => {
+                    unreachable!("pulldown_cmark::Options::ENABLE_MATH is not configured")
+                }
             }
             self.last_position = last_position
         }
@@ -671,7 +674,9 @@ where
                 );
                 self.writers.push(header.into())
             }
-            Tag::BlockQuote => {
+            // `pulldown_cmark::Options::ENABLE_GFM` is not configured so we shouldn't have
+            // a `BlockQuoteKind`` in the `Tag::BlockQuote`
+            Tag::BlockQuote(_) => {
                 // Just in case we're starting a new block quote in a nested context where
                 // We alternate indentation levels we want to remove trailing whitespace
                 // from the blockquote that we're about to push on top of
@@ -712,7 +717,7 @@ where
                         // If there are any other trailing lines those should be handled by
                         // The End(BlockQuote) event.
                     }
-                    Some((Event::Start(Tag::BlockQuote), next_range)) => {
+                    Some((Event::Start(Tag::BlockQuote(_)), next_range)) => {
                         let snippet = &self.input[range.start..next_range.start];
                         let link_defs = parse_link_reference_definitions(snippet, range.start);
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -274,7 +274,7 @@ pub(super) struct LinkReferenceDefinition<'a> {
     title: Option<LinkTitle<'a>>,
 }
 
-impl<'a> LinkReferenceDefinition<'a> {
+impl LinkReferenceDefinition<'_> {
     pub(super) fn range(&self) -> std::ops::Range<usize> {
         let start = self.label.range().expect("we have a label").start;
         let end = if let Some(title) = self.title.as_ref() {
@@ -310,7 +310,7 @@ pub(super) enum LinkDestination<'a> {
     Regular(Cow<'a, str>),
 }
 
-impl<'a> LinkDestination<'a> {
+impl LinkDestination<'_> {
     fn write<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
         match self {
             Self::Bracketed(text) => write!(writer, "<{text}>"),
@@ -451,7 +451,7 @@ impl<'a> From<(Cow<'a, str>, std::ops::Range<usize>)> for LinkLines<'a> {
     }
 }
 
-impl<'a> From<(&'static str, std::ops::Range<usize>)> for LinkLines<'a> {
+impl From<(&'static str, std::ops::Range<usize>)> for LinkLines<'_> {
     fn from(value: (&'static str, std::ops::Range<usize>)) -> Self {
         LinkLines(vec![(Cow::from(value.0), value.1)])
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -26,7 +26,7 @@ pub(super) struct TableState<'a> {
     col_index: usize,
 }
 
-impl<'a> Write for TableState<'a> {
+impl Write for TableState<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         self.write(s.to_owned().into());
         Ok(())

--- a/tests/source/empty_block_quotes.md
+++ b/tests/source/empty_block_quotes.md
@@ -25,3 +25,18 @@
 >   > > >
 >   >
 >   > >
+
+> [!NOTE]
+>
+
+> [!TIP]
+>
+
+> [!IMPORTANT]
+>
+
+> [!WARNING]
+>
+
+> [!CAUTION]
+>

--- a/tests/target/empty_block_quotes.md
+++ b/tests/target/empty_block_quotes.md
@@ -25,3 +25,18 @@
 >   >>>
 >   >
 >   >>
+
+> [!NOTE]
+>
+
+> [!TIP]
+>
+
+> [!IMPORTANT]
+>
+
+> [!WARNING]
+>
+
+> [!CAUTION]
+>

--- a/tests/target/math.md
+++ b/tests/target/math.md
@@ -1,0 +1,34 @@
+# Inline Math
+<!-- enclosing $ -->
+$a^2 + b^2 = c^2$
+
+<!-- enclosing $ - split over multple lines -->
+$d^2 + e^2
+= f^2$
+
+<!-- enclosing $` -->
+$`g^2 + h^2 = i^2`$
+
+<!-- enclosing $` - split over multiple lines -->
+$`j^2 + k^2
+= l^2`$
+
+
+# Math Block
+<!-- enclosing $$ -->
+$$m^2 + n^2 = o^2$$
+
+<!-- enclosing $$ -- split over multiple lines -->
+$$p^2 + q^2
+= r^2$$
+
+<!-- math code block -->
+```math
+s^2 + t^2 = u^2
+```
+
+<!-- math code block -- split over multiple lines -->
+```math
+v^2 + w^2
+= x^2
+```


### PR DESCRIPTION
This adds support for parsing math expressions and adds tags to blockquote nodes. I'm not enabling these features because it shouldn't be necessary to format these constructs. Math expressions are written in paragraphs, and the new blockquote tags will just show up as text that gets correctly formatted when it's there.