### PR TITLE
bump `pulldown-cmark` to `v0.12.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ missing-docs = "deny"
 
 [dependencies]
 itertools = "0.10"
-pulldown-cmark = { version = "0.11.3", default-features = false }
+pulldown-cmark = { version = "0.12.2", default-features = false }
 unicode-width = "0.1"
 unicode-segmentation = "1.9"
 clap = { version = "4.5.2", features = ["derive"], optional = true }

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,3 +1,5 @@
+mod end_list_at_last_item;
 mod loose_list;
 
+pub(crate) use end_list_at_last_item::ListEndAtLastItemExt;
 pub(crate) use loose_list::LooseListExt;

--- a/src/adapters/end_list_at_last_item.rs
+++ b/src/adapters/end_list_at_last_item.rs
@@ -1,0 +1,57 @@
+//! Something changed in pulldown-cmark v0.12.0 that messed with the `range.end` for lists.
+//!
+//! This module helps fix that issue by pinning the end of the list to it's last item's `range.end`.
+
+use pulldown_cmark::{Event, TagEnd};
+
+/// Conveniently turn any iterator that returns (Event, Range) into a ListEndAtLastItemAdapter
+pub(crate) trait ListEndAtLastItemExt<'input, I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    fn list_end_at_last_item(self) -> ListEndAtLastItemAdapter<I>;
+}
+
+// Blanket impl for all (Event<'input>, std::ops::Range<usize>) Iterators
+impl<'input, I> ListEndAtLastItemExt<'input, I> for I
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    fn list_end_at_last_item(self) -> ListEndAtLastItemAdapter<I> {
+        ListEndAtLastItemAdapter {
+            end_position: 0,
+            inner: self,
+        }
+    }
+}
+
+/// Iterator Adapter that modifies the source range of all `TagEnd::List` events to end at the
+/// same location as their last list item. This helps us preserve newlines between the end of
+/// a list and whatever element comes next.
+pub(crate) struct ListEndAtLastItemAdapter<I> {
+    end_position: usize,
+    inner: I,
+}
+
+impl<'input, I> Iterator for ListEndAtLastItemAdapter<I>
+where
+    I: Iterator<Item = (Event<'input>, std::ops::Range<usize>)>,
+{
+    type Item = (Event<'input>, std::ops::Range<usize>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (event, mut range) = self.inner.next()?;
+        match event {
+            Event::End(TagEnd::Item) => {
+                // `TagEnd::Item` should always precede `TagEnd::List`
+                self.end_position = range.end
+            }
+            Event::End(TagEnd::List(..)) => {
+                // Just update the current `TagEnd::List` with the last `TagEnd::Item` range.end
+                range.end = self.end_position
+            }
+            _ => {}
+        }
+        Some((event, range))
+    }
+}

--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -233,7 +233,7 @@ where
                 Event::End(
                     TagEnd::Heading(..)
                     | TagEnd::List(_)
-                    | TagEnd::BlockQuote
+                    | TagEnd::BlockQuote(..)
                     | TagEnd::CodeBlock
                     | TagEnd::Table
                     | TagEnd::HtmlBlock

--- a/src/adapters/test/loose_list/headers.md
+++ b/src/adapters/test/loose_list/headers.md
@@ -27,4 +27,4 @@ event=Text(Borrowed("Lorem ipsum dolor sit amet, consectetur adipiscing elit,"))
 event=End(Heading(H1)) range=129..188
 event=End(Item) range=94..188
 event=End(List(false)) range=94..188
-event=End(BlockQuote) range=92..188
+event=End(BlockQuote(None)) range=92..188

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, TagEnd};
 use pulldown_cmark::{LinkType, Parser, Tag};
 
-use crate::adapters::LooseListExt;
+use crate::adapters::{ListEndAtLastItemExt, LooseListExt};
 use crate::builder::{CodeBlockContext, CodeBlockFormatter};
 use crate::config::Config;
 use crate::footnote::FootnoteDefinition;
@@ -65,7 +65,10 @@ impl MarkdownFormatter {
         let options = pulldown_cmark_options!();
 
         let parser = Parser::new_with_broken_link_callback(input, options, Some(&mut callback));
-        let iter = parser.into_offset_iter().all_loose_lists();
+        let iter = parser
+            .into_offset_iter()
+            .all_loose_lists()
+            .list_end_at_last_item();
 
         let fmt_state = FormatState::new(input, self, iter);
         fmt_state.format()


### PR DESCRIPTION
Match on new `DefinitionList` `Tag` and `TagEnd`s, and fixup some code based on changes to `BlockQuote`s

**Note**: The project doesn't currently support definition lists because `Options::ENABLE_DEFINITION_LIST` isn't enabled.

Also, There were some changes that occurred in v0.12 of `pulldown-cmark` that changed the source range for lists. To keep the previous behavior I'm clamping the end of the list to its last list item.