### PR TITLE
Do a better job of preserving leading whitespace in HTML blocks

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -528,9 +528,7 @@ where
                     let starts_with_escape = self.input[..range.start].ends_with('\\');
                     let newlines = self.count_newlines(&range);
                     let text_from_source = &self.input[range];
-                    let mut text = if self.in_html_block() {
-                        text_from_source
-                    } else if text_from_source.is_empty() {
+                    let mut text = if text_from_source.is_empty() || self.in_html_block() {
                         // This seems to happen when the parsed text is whitespace only.
                         // To preserve leading whitespace use the parsed text instead.
                         parsed_text.as_ref()

--- a/tests/commonmark_v0_30_spec.rs
+++ b/tests/commonmark_v0_30_spec.rs
@@ -1240,8 +1240,6 @@ fn markdown_html_blocks_150() {
     // https://spec.commonmark.org/0.30/#example-150
     test_identical_markdown_events!(r##" <div>
   *hello*
-         <foo><a>"##,r##"<div>
-  *hello*
          <foo><a>"##);
 }
 
@@ -1530,8 +1528,6 @@ fn markdown_html_blocks_183() {
     // https://spec.commonmark.org/0.30/#example-183
     test_identical_markdown_events!(r##"  <!-- foo -->
 
-    <!-- foo -->"##,r##"<!-- foo -->
-
     <!-- foo -->"##);
 }
 
@@ -1539,8 +1535,6 @@ fn markdown_html_blocks_183() {
 fn markdown_html_blocks_184() {
     // https://spec.commonmark.org/0.30/#example-184
     test_identical_markdown_events!(r##"  <div>
-
-    <div>"##,r##"<div>
 
     <div>"##);
 }
@@ -1617,16 +1611,6 @@ fn markdown_html_blocks_191() {
     </td>
 
   </tr>
-
-</table>"##,r##"<table>
-
-<tr>
-
-    <td>
-      Hi
-    </td>
-
-</tr>
 
 </table>"##);
 }

--- a/tests/gfm_spec_v0_29_0_gfm_13.rs
+++ b/tests/gfm_spec_v0_29_0_gfm_13.rs
@@ -1022,8 +1022,6 @@ fn gfm_markdown_html_blocks_120() {
     // https://github.github.com/gfm/#example-120
     test_identical_markdown_events!(r##" <div>
   *hello*
-         <foo><a>"##,r##"<div>
-  *hello*
          <foo><a>"##);
 }
 
@@ -1300,8 +1298,6 @@ fn gfm_markdown_html_blocks_152() {
     // https://github.github.com/gfm/#example-152
     test_identical_markdown_events!(r##"  <!-- foo -->
 
-    <!-- foo -->"##,r##"<!-- foo -->
-
     <!-- foo -->"##);
 }
 
@@ -1309,8 +1305,6 @@ fn gfm_markdown_html_blocks_152() {
 fn gfm_markdown_html_blocks_153() {
     // https://github.github.com/gfm/#example-153
     test_identical_markdown_events!(r##"  <div>
-
-    <div>"##,r##"<div>
 
     <div>"##);
 }
@@ -1387,16 +1381,6 @@ fn gfm_markdown_html_blocks_160() {
     </td>
 
   </tr>
-
-</table>"##,r##"<table>
-
-<tr>
-
-    <td>
-      Hi
-    </td>
-
-</tr>
 
 </table>"##);
 }

--- a/tests/spec/CommonMark/commonmark_v0_30_spec.json
+++ b/tests/spec/CommonMark/commonmark_v0_30_spec.json
@@ -1260,7 +1260,6 @@
   },
   {
     "markdown": " <div>\n  *hello*\n         <foo><a>\n",
-    "formattedMarkdown": "<div>\n  *hello*\n         <foo><a>",
     "html": " <div>\n  *hello*\n         <foo><a>\n",
     "example": 150,
     "start_line": 2483,
@@ -1525,7 +1524,6 @@
   },
   {
     "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
-    "formattedMarkdown": "<!-- foo -->\n\n    <!-- foo -->",
     "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
     "example": 183,
     "start_line": 2974,
@@ -1534,7 +1532,6 @@
   },
   {
     "markdown": "  <div>\n\n    <div>\n",
-    "formattedMarkdown": "<div>\n\n    <div>",
     "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
     "example": 184,
     "start_line": 2985,
@@ -1591,7 +1588,6 @@
   },
   {
     "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
-    "formattedMarkdown": "<table>\n\n<tr>\n\n    <td>\n      Hi\n    </td>\n\n</tr>\n\n</table>",
     "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
     "example": 191,
     "start_line": 3134,

--- a/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
+++ b/tests/spec/GitHub/gfm_spec_v0_29_0_gfm_13.json
@@ -1126,7 +1126,6 @@
   },
   {
     "markdown": " <div>\n  *hello*\n         <foo><a>\n",
-    "formattedMarkdown": "<div>\n  *hello*\n         <foo><a>",
     "html": " <div>\n  *hello*\n         <foo><a>\n",
     "example": 120,
     "start_line": 2151,
@@ -1415,7 +1414,6 @@
   },
   {
     "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
-    "formattedMarkdown": "<!-- foo -->\n\n    <!-- foo -->",
     "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
     "example": 152,
     "start_line": 2621,
@@ -1425,7 +1423,6 @@
   },
   {
     "markdown": "  <div>\n\n    <div>\n",
-    "formattedMarkdown": "<div>\n\n    <div>",
     "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
     "example": 153,
     "start_line": 2632,
@@ -1489,7 +1486,6 @@
   },
   {
     "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
-    "formattedMarkdown": "<table>\n\n<tr>\n\n    <td>\n      Hi\n    </td>\n\n</tr>\n\n</table>",
     "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
     "example": 160,
     "start_line": 2781,

--- a/tests/target/html_blocks.md
+++ b/tests/target/html_blocks.md
@@ -1,0 +1,49 @@
+<!-- Top Level HTML Blocks -->
+<div>
+<span>Inline HTML in an HTML block</span>
+</div>
+
+<div>
+  <span>Extra leading space in an HTML block</span>
+</div>
+
+  <div>
+    <span>All indented in an HTML block</span>
+  </div>
+
+
+<!-- Blockquotes -->
+
+> # HTML In a Blockquote
+> <div>
+> <span>Inline HTML in a blockquote HTML block</span>
+> </div>
+
+> # More HTML In a Blockquote
+> <div>
+>   <span>Extra leading space in a blockquote HTML block</span>
+> </div>
+
+> # Even More HTML In a Blockquote
+>   <div>
+>     <span>All indented in a blockquote HTML block</span>
+>   </div>
+
+
+<!-- Lists -->
+
+* # HTML In a List
+  <div>
+  <span>HTML in a list HTML block</span>
+  </div>
+
+
+* # More HTML In a List
+  <div>
+    <span>Extra leading space in a list HTML block</span>
+  </div>
+
+* # Even More HTML In a List
+    <div>
+      <span>All indented in a list HTML block</span>
+    </div>


### PR DESCRIPTION
Got to remove several `formattedMarkdown` keys from the test JSON files, so that means we're not messing with the HTML formatting, and I'm pretty happy about that. Maybe I'll add the option to format HTML one of these days, but for now I'm cool with it not being formatted.