### PR TITLE
bump  `pulldown-cmark` to `v0.13.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ missing-docs = "deny"
 
 [dependencies]
 itertools = "0.10"
-pulldown-cmark = { version = "0.12.2", default-features = false }
+pulldown-cmark = { version = "0.13.0", default-features = false }
 unicode-width = "0.1"
 unicode-segmentation = "1.9"
 clap = { version = "4.5.2", features = ["derive"], optional = true }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1061,6 +1061,12 @@ where
             Tag::DefinitionList | Tag::DefinitionListTitle | Tag::DefinitionListDefinition => {
                 unreachable!("pulldown_cmark::Options::ENABLE_DEFINITION_LIST is not configured")
             }
+            Tag::Superscript => {
+                unreachable!("pulldown_cmark::Options::ENABLE_SUPERSCRIPT is not configured")
+            }
+            Tag::Subscript => {
+                unreachable!("pulldown_cmark::Options::ENABLE_SUBSCRIPT is not configured")
+            }
         }
         Ok(())
     }
@@ -1276,6 +1282,9 @@ where
                     LinkType::Collapsed | LinkType::CollapsedUnknown => write!(self, "][]")?,
                     LinkType::Shortcut | LinkType::ShortcutUnknown => write!(self, "]")?,
                     LinkType::Autolink | LinkType::Email => write!(self, ">")?,
+                    LinkType::WikiLink { .. } => {
+                        unreachable!("pulldown_cmark::Options::ENABLE_WIKILINKS is not configured")
+                    }
                 }
             }
             TagEnd::Table => {
@@ -1313,6 +1322,12 @@ where
             | TagEnd::DefinitionListTitle
             | TagEnd::DefinitionListDefinition => {
                 unreachable!("pulldown_cmark::Options::ENABLE_DEFINITION_LIST is not configured")
+            }
+            TagEnd::Superscript => {
+                unreachable!("pulldown_cmark::Options::ENABLE_SUPERSCRIPT is not configured")
+            }
+            TagEnd::Subscript => {
+                unreachable!("pulldown_cmark::Options::ENABLE_SUBSCRIPT is not configured")
             }
         }
         Ok(())


### PR DESCRIPTION
Take advantage of bugfixes released in `v0.13.0`. Note that this projects doesn't support `Options::ENABLE_WIKILINKS`, `Options::ENABLE_SUPERSCRIPT`, or `Options::ENABLE_SUBSCRIPT` yet.