### PR TITLE
replace blockquote comment with `debug_assert!`

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -675,9 +675,11 @@ where
                 );
                 self.writers.push(header.into())
             }
-            // `pulldown_cmark::Options::ENABLE_GFM` is not configured so we shouldn't have
-            // a `BlockQuoteKind`` in the `Tag::BlockQuote`
-            Tag::BlockQuote(_) => {
+            Tag::BlockQuote(kind) => {
+                debug_assert!(
+                    kind.is_none(),
+                    "pulldown_cmark::Options::ENABLE_GFM is not configured"
+                );
                 // Just in case we're starting a new block quote in a nested context where
                 // We alternate indentation levels we want to remove trailing whitespace
                 // from the blockquote that we're about to push on top of


### PR DESCRIPTION
Because `Options::ENABLE_GFM` isn't enabled, blockquotes should always have a kind of `None`.