### PR TITLE
better support for `Event::HardBreak`

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -505,13 +505,17 @@ where
     pub fn format(mut self) -> Result<String, std::fmt::Error> {
         while let Some((event, range)) = self.events.next() {
             tracing::debug!(?event, ?range, last_position = self.last_position);
-            let mut last_position = self.input[..range.end]
-                .bytes()
-                .rposition(|b| !b.is_ascii_whitespace())
-                .map(
-                    |offset| offset + 1, /* +1 to start on the whitespace or end of input */
-                )
-                .unwrap_or(0);
+            let mut last_position = if matches!(event, Event::HardBreak) {
+                range.end
+            } else {
+                self.input[..range.end]
+                    .bytes()
+                    .rposition(|b| !b.is_ascii_whitespace())
+                    .map(
+                        |offset| offset + 1, /* +1 to start on the whitespace or end of input */
+                    )
+                    .unwrap_or(0)
+            };
 
             match event {
                 Event::Start(tag) => {

--- a/src/test.rs
+++ b/src/test.rs
@@ -143,5 +143,9 @@ mod tester {
 
         let result = rewrite_markdown("[`\r``]").unwrap();
         assert_eq!(result, "[` ``]");
+
+        let input = ">z\\\rS[\nz\\\rS#`~\\\r33~[\n#";
+        let result = rewrite_markdown(input).unwrap();
+        assert_eq!(result, "> z\\\rS[\n> z\\\rS#`~\\\r33~[\n#");
     }
 }


### PR DESCRIPTION
To prevent adding extra newlines the `last_position` is updated to the end of the `Event::HardBreak`.