### PR TITLE
fix link reference definition parsing

### DIFF
--- a/src/links.rs
+++ b/src/links.rs
@@ -646,6 +646,7 @@ fn parse_link_reference_definition(
                 if is_last {
                     let url = Cow::from(&input[idx..=idx]);
                     builder.set_url(LinkDestination::Regular(url), idx..idx, offset);
+                    parsed_until = idx;
                     break;
                 }
 
@@ -678,6 +679,7 @@ fn parse_link_reference_definition(
                             if is_last {
                                 let url = Cow::from(&input[start..=idx]);
                                 builder.set_url(LinkDestination::Regular(url), start..idx, offset);
+                                parsed_until = idx;
                                 break;
                             }
                             continue;
@@ -916,6 +918,12 @@ mod test {
             definition: "[.]: [",
             label: ".",
             url: LinkDestination::Regular("[".into()),
+        }
+
+        check_parsed_link_reference_definition! {
+            definition: "[.]:[]:[]",
+            label: ".",
+            url: LinkDestination::Regular("[]:[]".into()),
         }
     }
 

--- a/tests/target/reference_link_definitions.md
+++ b/tests/target/reference_link_definitions.md
@@ -96,3 +96,6 @@
 [7️⃣-teen]
 
 [7️⃣-teen]: 7️⃣-teen-url '7️⃣-teen-title'
+
+<!-- Odd Cases found when fuzzing -->
+[.]: []:[]


### PR DESCRIPTION
The `parsed_until` variable wasn't properly updated in some cases, so the parser thought it needed to pull additional definitions out of the snippet for some stranger edge cases found when fuzz testing.