### PR TITLE
prevent interpretation as a table without leading `|` characters

### DIFF
--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -29,6 +29,11 @@ impl Write for Paragraph {
             // then push a space so we can reflow text
             self.buffer.push(' ');
         } else {
+            // Prevent the next pass of the parser from accidentaly interpreting a table
+            // without a leading |
+            if s.starts_with("-|") && self.buffer.trim_end().ends_with('|') {
+                self.buffer.push('\\');
+            }
             self.buffer.push_str(s);
         }
 

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -1,0 +1,4 @@
+<!-- Don't interpret as a table without a leading `|` -->
+
+>6|
+-|

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -1,0 +1,4 @@
+<!-- Don't interpret as a table without a leading `|` -->
+
+> 6|
+> \-|


### PR DESCRIPTION
After a softbreak `-|` could be interpreted as a table if the previous line ended in a `|`.