### PR TITLE
Fix idempotent issue where nested list is interpreted as setext header

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -11,6 +11,9 @@ use std::num::ParseIntError;
 //
 const LIST_INDENTATION: &str = "                    ";
 const ZERO_PADDING: &str = "00000000000000000000";
+pub(crate) static LIST_START_CHARS: &[char] = &[
+    '*', '+', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+];
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum ListMarker {

--- a/tests/source/empty_lists.md
+++ b/tests/source/empty_lists.md
@@ -94,3 +94,13 @@
 08.
 09.
 010.
+
+<!-- case with tabs (found when fuzzing)
+     To prevent the `-` from getting interpreted as a setext header the list is given another
+     newline separator.
+-->
+
+*[
+-		+*[
+	[
+	-	-z*	

--- a/tests/target/empty_lists.md
+++ b/tests/target/empty_lists.md
@@ -94,3 +94,15 @@
 08.
 09.
 010.
+
+<!-- case with tabs (found when fuzzing)
+     To prevent the `-` from getting interpreted as a setext header the list is given another
+     newline separator.
+-->
+
+*[
+-       +*[
+  [
+
+  -
+    -z*


### PR DESCRIPTION
To prevent this issue we add an extra newline to clearly disambiguate the two interpretations of the code.