### PR TITLE
escape `!` in paragraph if preceded by `<` and within a blockquote

### DIFF
--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -1,3 +1,9 @@
+<!-- Don't interpret as inline HTML -->
+
+>*<!fJ<!fJ`
+TT
+
+
 <!-- Don't interpret as a table without a leading `|` -->
 
 >6|

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -1,3 +1,9 @@
+<!-- Don't interpret as inline HTML -->
+
+> *<\!fJ<\!fJ`
+> TT
+
+
 <!-- Don't interpret as a table without a leading `|` -->
 
 > 6|


### PR DESCRIPTION
In order to prevent `<! {some text}\n>` from being interpreted as an inline HTML tag the `!` is escaped.