### PR TITLE
fix blockquote indentation after removing a `>` from indentation stack

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1189,6 +1189,23 @@ where
                         *indentation = popped_indentation
                     }
                 }
+
+                // FIXME(ytmimi) let chains would make this much nicer to write.
+                //
+                // If there's another event...
+                if let Some((event, _)) = self.events.peek() {
+                    // and it's not a TagEnd::BlockQuote...
+                    if !matches!(event, Event::End(TagEnd::BlockQuote(_))) {
+                        // and we still have indentation on the stack...
+                        if let Some(last) = self.indentation.last_mut() {
+                            // and the indentaion is ">"...
+                            if last == ">" {
+                                // update the indentation
+                                *last = "> ".into()
+                            }
+                        }
+                    }
+                }
             }
             TagEnd::CodeBlock => {
                 debug_assert!(matches!(

--- a/tests/source/empty_block_quotes.md
+++ b/tests/source/empty_block_quotes.md
@@ -42,3 +42,7 @@
 
 > [!CAUTION]
 >
+
+<!-- drop a blockquote level followed by code block (found when fuzzing)-->
+>>
+>     *

--- a/tests/target/empty_block_quotes.md
+++ b/tests/target/empty_block_quotes.md
@@ -42,3 +42,7 @@
 
 > [!CAUTION]
 >
+
+<!-- drop a blockquote level followed by code block (found when fuzzing)-->
+>>
+>     *


### PR DESCRIPTION
Turns out that we forgot to set any `>` to `> ` after popping a blockquote off the indentation stack. This lead to idempotent issues when an indented code block would follow the remaining `>` because there would be one fewer space than expected.

Again, thank you fuzz testing for helping me find this one.