### PR TITLE
Add escaping after a hardbreak in a paragraph.

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -22,27 +22,29 @@ where
             return false;
         }
 
-        let Some(first_char) = input.chars().next() else {
-            return false;
-        };
+        needs_escape(input)
+    }
+}
 
-        let is_setext_heading = |value: u8| input.trim_end().bytes().all(|b| b == value);
-        let is_unordered_list_marker = |value: &str| input.starts_with(value);
-        let is_thematic_break = |value: u8| input.bytes().all(|b| b == value || b == b' ');
+pub(crate) fn needs_escape(input: &str) -> bool {
+    let Some(first_char) = input.chars().next() else {
+        return false;
+    };
 
-        match first_char {
-            '#' => ATX_HEADER_ESCAPES
-                .iter()
-                .any(|header| input.starts_with(header)),
-            '=' => is_setext_heading(b'='),
-            '-' => {
-                is_unordered_list_marker("- ") || is_setext_heading(b'-') || is_thematic_break(b'-')
-            }
-            '_' => is_thematic_break(b'_'),
-            '*' => is_unordered_list_marker("* ") || is_thematic_break(b'*'),
-            '+' => is_unordered_list_marker("+ "),
-            '>' => true,
-            _ => false,
-        }
+    let is_setext_heading = |value: u8| input.trim_end().bytes().all(|b| b == value);
+    let is_unordered_list_marker = |value: &str| input.starts_with(value);
+    let is_thematic_break = |value: u8| input.bytes().all(|b| b == value || b == b' ');
+
+    match first_char {
+        '#' => ATX_HEADER_ESCAPES
+            .iter()
+            .any(|header| input.starts_with(header)),
+        '=' => is_setext_heading(b'='),
+        '-' => is_unordered_list_marker("- ") || is_setext_heading(b'-') || is_thematic_break(b'-'),
+        '_' => is_thematic_break(b'_'),
+        '*' => is_unordered_list_marker("* ") || is_thematic_break(b'*'),
+        '+' => is_unordered_list_marker("+ "),
+        '>' | ':' => true,
+        _ => false,
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -173,7 +173,7 @@ where
     }
 
     /// Peek at the next Markdown Event and it's original position in the input
-    fn peek_with_range(&mut self) -> Option<(&Event, &Range<usize>)> {
+    fn peek_with_range(&mut self) -> Option<(&Event<'i>, &Range<usize>)> {
         self.events.peek().map(|(e, r)| (e, r))
     }
 
@@ -595,9 +595,9 @@ where
                         let code = split_lines(snippet)
                             .map(|s| self.trim_leading_indentation(s))
                             .join("\n");
-                        write!(self, "{}", code)?;
+                        write!(self, "{code}")?;
                     } else {
-                        write!(self, "{}", snippet)?;
+                        write!(self, "{snippet}")?;
                     }
                 }
                 Event::SoftBreak => {

--- a/src/links.rs
+++ b/src/links.rs
@@ -507,10 +507,10 @@ impl<'a> From<Vec<(Cow<'a, str>, std::ops::Range<usize>)>> for LinkLines<'a> {
     }
 }
 
-pub fn parse_link_reference_definitions(
-    input: &str,
+pub fn parse_link_reference_definitions<'i>(
+    input: &'i str,
     mut offset: usize,
-) -> Vec<LinkReferenceDefinition> {
+) -> Vec<LinkReferenceDefinition<'i>> {
     let mut refernce_definitions = vec![];
     let mut input = input;
 
@@ -550,10 +550,10 @@ enum MultiLinePhase {
 }
 
 /// Parse a single reference definition from
-fn parse_link_reference_definition(
-    input: &str,
+fn parse_link_reference_definition<'i>(
+    input: &'i str,
     offset: usize,
-) -> Option<(LinkReferenceDefinition, usize)> {
+) -> Option<(LinkReferenceDefinition<'i>, usize)> {
     let mut phase = LinkParserPhase::FindOpeningBracket;
     let mut builder = LinkReferenceDefinitionBuilder::new();
     let mut start = 0;

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -1,3 +1,5 @@
+use crate::escape::needs_escape;
+
 use std::fmt::Write;
 use textwrap::Options as TextWrapOptions;
 
@@ -32,6 +34,12 @@ impl Write for Paragraph {
             // Prevent the next pass of the parser from accidentaly interpreting a table
             // without a leading |
             if s.starts_with("-|") && self.buffer.trim_end().ends_with('|') {
+                self.buffer.push('\\');
+            }
+
+            // Prevent the next pass from ignoring the hard break or misinterpreting `s`
+            // as something other than text in a paragraph
+            if self.buffer.ends_with(MARKDOWN_HARD_BREAK) && needs_escape(s) {
                 self.buffer.push('\\');
             }
             self.buffer.push_str(s);

--- a/src/table.rs
+++ b/src/table.rs
@@ -138,7 +138,7 @@ impl<'a> TableState<'a> {
             .map(|grapheme| unicode_str_width(grapheme).saturating_sub(1))
             .sum();
         size = size.saturating_sub(offset);
-        write!(buffer, " {value:<0$} |", size)
+        write!(buffer, " {value:<size$} |")
     }
 
     fn rewrite_header(&self, buffer: &mut String) -> std::fmt::Result {

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -8,3 +8,7 @@ TT
 
 >6|
 -|
+
+<!-- space hard break followed by paragraph with single `-` -->
+<  
+    -

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -8,3 +8,7 @@
 
 > 6|
 > \-|
+
+<!-- space hard break followed by paragraph with single `-` -->
+<  
+\-


### PR DESCRIPTION
This prevents the markdown events from changing after formatting.