### PR TITLE
escape backtick (`) and tilde (~) chars

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -44,6 +44,7 @@ pub(crate) fn needs_escape(input: &str) -> bool {
     let is_setext_heading = |value: u8| input.trim_end().bytes().all(|b| b == value);
     let is_unordered_list_marker = |value: &str| input.starts_with(value);
     let is_thematic_break = |value: u8| input.bytes().all(|b| b == value || b == b' ');
+    let is_fenced_code_block = |value: &str| input.starts_with(value);
 
     match first_char {
         '#' => ATX_HEADER_ESCAPES
@@ -54,6 +55,8 @@ pub(crate) fn needs_escape(input: &str) -> bool {
         '_' => is_thematic_break(b'_'),
         '*' => is_unordered_list_marker("* ") || is_thematic_break(b'*'),
         '+' => is_unordered_list_marker("+ "),
+        '`' => is_fenced_code_block("```"),
+        '~' => is_fenced_code_block("~~~"),
         '>' | ':' => true,
         _ => false,
     }

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -12,3 +12,11 @@ TT
 <!-- space hard break followed by paragraph with single `-` -->
 <  
     -
+
+<!-- Don't interpret the '```' as the start of a fenced code block -->
+--
+    ```>
+
+<!-- Don't interpret the '```' as the start of a fenced code block -->
+--
+    ~~~>

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -12,3 +12,11 @@
 <!-- space hard break followed by paragraph with single `-` -->
 <  
 \-
+
+<!-- Don't interpret the '```' as the start of a fenced code block -->
+--
+\```>
+
+<!-- Don't interpret the '```' as the start of a fenced code block -->
+--
+\~~~>


### PR DESCRIPTION
Now, any set of three or more consecutive (`) or (~) chars will be escaped to prevent future formatting runs interpreting them as the start of a fenced code block.