### PR TITLE
let `Event::HardBreak` start a paragraph in the `LooseListAdapter`

### DIFF
--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -123,6 +123,7 @@ where
     fn is_tight_list(event: &Event<'_>) -> bool {
         match event {
             Event::Text(_)
+            | Event::HardBreak
             | Event::Code(_)
             | Event::FootnoteReference(_)
             | Event::TaskListMarker(_)

--- a/tests/source/empty_lists.md
+++ b/tests/source/empty_lists.md
@@ -104,3 +104,7 @@
 -		+*[
 	[
 	-	-z*	
+
+<!-- Tight list that starts with a hard break should be idempotent -->
+* \
+~

--- a/tests/target/empty_lists.md
+++ b/tests/target/empty_lists.md
@@ -106,3 +106,7 @@
 
   -
     -z*
+
+<!-- Tight list that starts with a hard break should be idempotent -->
+* \
+  ~


### PR DESCRIPTION
The indentation after the hardbreak wouldn't be set as expected without this change.