### PR TITLE
don't remove ` or ~ from the info string or a fenced code block

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -905,15 +905,20 @@ where
                             return Ok(());
                         }
 
+                        let marker_char = self.input[range.start..]
+                            .chars()
+                            .next()
+                            .expect("should have found a ` or ~");
+
                         let starts_with_space = self.input[range.clone()]
-                            .trim_start_matches(['`', '~'])
+                            .trim_start_matches(marker_char)
                             .starts_with(char::is_whitespace);
 
                         let info_string = self.input[range]
                             .lines()
                             .next()
                             .unwrap_or_else(|| info_string.as_ref())
-                            .trim_start_matches(['`', '~'])
+                            .trim_start_matches(marker_char)
                             .trim();
 
                         if starts_with_space {

--- a/tests/source/empty_code_blocks.md
+++ b/tests/source/empty_code_blocks.md
@@ -75,3 +75,17 @@
 >>           >
 >>           >
 >>           >       ```
+
+<!-- Don't remove ` from the info string of a ~ code block -->
+~~~`
+~~~
+
+~~~ `
+~~~
+
+<!-- Don't remove ~ from the info string of a ` code block -->
+```~
+```
+
+``` ~
+```

--- a/tests/target/empty_code_blocks.md
+++ b/tests/target/empty_code_blocks.md
@@ -59,3 +59,17 @@
 >>     0004. > 0004)
 >>           >       ```super_nested_next_line_list_with_newlines
 >>           >       ```
+
+<!-- Don't remove ` from the info string of a ~ code block -->
+~~~`
+~~~
+
+~~~ `
+~~~
+
+<!-- Don't remove ~ from the info string of a ` code block -->
+```~
+```
+
+``` ~
+```


### PR DESCRIPTION
if a code block starts with `` ` `` don't remove leading `~`, and if the code block starts with `~` don't remove leading `` ` ``.