### PR TITLE
escape trailing escape in link reference definitions

### DIFF
--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -85,3 +85,6 @@ TT
 <
     <p  
 ! 
+
+<!-- Escape the escape so that we don't escape the closing `]`on the next formatting run -->
+[\ ]:]

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -85,3 +85,6 @@
 <
 \<p  
 !
+
+<!-- Escape the escape so that we don't escape the closing `]`on the next formatting run -->
+[\\]: ]


### PR DESCRIPTION
This prevents future formatting runs from interpreting `]` as `\]`