### PR TITLE
fix issue when calculating the minimum cell width in a table

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -48,7 +48,7 @@ impl<'a> TableState<'a> {
         Self {
             alignment,
             headers: Vec::with_capacity(capacity),
-            max_column_width: vec![3; capacity],
+            max_column_width: vec![0; capacity],
             body: vec![],
             write_to_body: false,
             col_index: 0,
@@ -100,6 +100,13 @@ impl<'a> TableState<'a> {
         }
     }
 
+    fn update_column_width_for_alignment(&mut self) {
+        for width in self.max_column_width.iter_mut() {
+            // 3 = `---` or `:--` or `--:` or `:-:`
+            *width = std::cmp::max(*width, 3);
+        }
+    }
+
     fn write_cell(&mut self, text: Cow<'a, str>) {
         let row = self
             .body
@@ -125,7 +132,10 @@ impl<'a> TableState<'a> {
         }
     }
 
-    pub(super) fn format(self) -> Result<String, std::fmt::Error> {
+    pub(super) fn format(mut self) -> Result<String, std::fmt::Error> {
+        // Just in case adjust the column widths for the allignemnt before formatting.
+        self.update_column_width_for_alignment();
+
         let mut result = String::new();
         self.rewrite_header(&mut result)?;
         self.rewrite_alignment(&mut result)?;

--- a/tests/source/github_flavored_markdown_tables.md
+++ b/tests/source/github_flavored_markdown_tables.md
@@ -149,3 +149,8 @@ Name | Description | Default?
 `ws` | Enables WebSockets support via [`extract::ws`] | No
 `form` | Enables the `Form` extractor | Yes
 `query` | Enables the `Query` extractor | Yes
+
+
+<!-- test case found when fuzzing -->
+__|
+-|

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -18,9 +18,9 @@
   \|-
 
 <!-- Escape any `|` chars inside a table -->
-| `6   |
-| ---- |
-| [\|  |
+| `6  |
+| --- |
+| [\| |
 
 <!-- Escape '-|' even when there are a lot of trailing spaces -->
 [|        

--- a/tests/target/github_flavored_markdown_tables.md
+++ b/tests/target/github_flavored_markdown_tables.md
@@ -149,3 +149,8 @@
 | `ws`           | Enables WebSockets support via [`extract::ws`]                                              | No       |
 | `form`         | Enables the `Form` extractor                                                                | Yes      |
 | `query`        | Enables the `Query` extractor                                                               | Yes      |
+
+
+<!-- test case found when fuzzing -->
+| __  |
+| --- |


### PR DESCRIPTION
This fixes an idempotent issue when the header or row value was less than the minimum alignment width of 3.