### PR TITLE
check if text that looks like thematic break in paragraph needs escaping

### DIFF
--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -68,6 +68,19 @@ impl Write for Paragraph {
                 self.buffer.push('\\');
             }
 
+            let is_thematic_break = |input: &str, marker: char| -> bool {
+                input
+                    .chars()
+                    .all(|c| matches!(c, ' ' | '\t') || c == marker)
+                    && input.chars().filter(|c| *c == marker).count() >= 3
+            };
+
+            if (self.buffer.ends_with('\n') || self.buffer.is_empty())
+                && ['-', '_', '*'].iter().any(|c| is_thematic_break(s, *c))
+            {
+                self.buffer.push('\\');
+            }
+
             self.buffer.push_str(s);
         }
 

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -88,3 +88,14 @@ TT
 
 <!-- Escape the escape so that we don't escape the closing `]`on the next formatting run -->
 [\ ]:]
+
+
+<!-- escape what looks like rule -->
+[.]:a
+    ***
+
+[.]:b
+    ---
+
+[.]:c
+    ___

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -88,3 +88,14 @@
 
 <!-- Escape the escape so that we don't escape the closing `]`on the next formatting run -->
 [\\]: ]
+
+
+<!-- escape what looks like rule -->
+[.]: a
+\***
+
+[.]: b
+\---
+
+[.]: c
+\___


### PR DESCRIPTION
This came up in fuzz testing with a themtic break, but I suspect that escaping the start of a paragraph will be useful in other scenarios as well.