### PR TITLE
escape text that looks like a table inside multi-line code.

### DIFF
--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -26,6 +26,16 @@ TT
 [|        
         -|
 
+<!--
+    Escape the multi-line code text that looks like the delimter rows of a
+    GitHub Flavored Markdown Table, so it won't be interpreted as one on future formatting runs.
+-->
+ >*  `qy|?-
+-|-
+|-
+|-   ` -`
+`
+
 <!-- space hard break followed by paragraph with single `-` -->
 <  
     -

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -26,6 +26,16 @@
 [|        
 \-|
 
+<!--
+    Escape the multi-line code text that looks like the delimter rows of a
+    GitHub Flavored Markdown Table, so it won't be interpreted as one on future formatting runs.
+-->
+> * `qy|?-
+>   \-|-
+>   \|-
+>   \|-   ` -`
+>   `
+
 <!-- space hard break followed by paragraph with single `-` -->
 <  
 \-


### PR DESCRIPTION
These updates should help escape any text inside multi-line `Event::Code`, but when I was fuzz testing this was the case that failed.