### PR TITLE
escape text in paragraphs that looks like an empty header `#`

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -58,7 +58,9 @@ pub(crate) fn needs_escape(input: &str) -> bool {
             break;
         }
 
-        leading_marker_count <= 6 && whitespace_after_header_marker
+        let empty_header = || input.chars().all(|c| c == '#');
+
+        leading_marker_count <= 6 && (whitespace_after_header_marker || empty_header())
     };
     let is_setext_heading = |value: u8| input.trim_end().bytes().all(|b| b == value);
     let is_unordered_list_marker = |value: &str| input.starts_with(value);

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -47,7 +47,7 @@ impl WriteEvent<'_> for Paragraph {
             self.buffer.push('\\');
         }
 
-        if s.starts_with('#') && needs_escape {
+        if self.buffer.ends_with('\n') && s.starts_with('#') && needs_escape {
             self.buffer.push('\\');
         }
 

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -144,3 +144,26 @@ TT
 <!
     ####### *<!  
 ``
+
+<!-- escape '#' so that it's not treated as an empty header -->
+A  
+    #
+
+B  
+    ##
+
+C  
+    ###
+
+D  
+    ####
+
+E  
+    #####
+
+F  
+    ######
+
+<!-- doesn't need an escape because a header can only be up to h6 -->
+G  
+    #######

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -144,3 +144,26 @@
 <!
 ####### *<!  
 ``
+
+<!-- escape '#' so that it's not treated as an empty header -->
+A  
+\#
+
+B  
+\##
+
+C  
+\###
+
+D  
+\####
+
+E  
+\#####
+
+F  
+\######
+
+<!-- doesn't need an escape because a header can only be up to h6 -->
+G  
+#######


### PR DESCRIPTION
Before these changes we wouldn't escape text after a soft or hard break that looked like an empty header.