### PR TITLE
updated `needs_escape` to return an `EscapKind`

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -4,10 +4,12 @@ impl<I> FormatState<'_, '_, I>
 where
     I: Iterator,
 {
-    pub(super) fn needs_escape(&mut self, input: &str, is_inline_element: bool) -> bool {
-        let Some(first_char) = input.chars().next() else {
-            return false;
-        };
+    pub(super) fn needs_escape(
+        &mut self,
+        input: &str,
+        is_inline_element: bool,
+    ) -> Option<EscapeKind> {
+        let first_char = input.chars().next()?;
 
         if !is_inline_element {
             if !self.last_was_softbreak {
@@ -20,16 +22,16 @@ where
                 //
                 // As an example, see <https://spec.commonmark.org/0.30/#example-70> as a case
                 // where the semantics would change without an escape after removing indentation.
-                return false;
+                return None;
             }
 
             // Don't interpret the `>` as a blockquote
             if first_char == '>' {
-                return true;
+                return Some(EscapeKind::SingleLine(SingleLineEscape::BlockQuote));
             }
 
             if input.len() <= 2 {
-                return false;
+                return None;
             }
         }
 
@@ -37,10 +39,8 @@ where
     }
 }
 
-pub(crate) fn needs_escape(input: &str) -> bool {
-    let Some(first_char) = input.chars().next() else {
-        return false;
-    };
+pub(crate) fn needs_escape(input: &str) -> Option<EscapeKind> {
+    let first_char = input.chars().next()?;
 
     let is_atx_heading = || -> bool {
         let mut leading_marker_count = 0;
@@ -68,15 +68,99 @@ pub(crate) fn needs_escape(input: &str) -> bool {
     let is_fenced_code_block = |value: &str| input.starts_with(value);
 
     match first_char {
-        '#' => is_atx_heading(),
-        '=' => is_setext_heading(b'='),
-        '-' => is_unordered_list_marker("- ") || is_setext_heading(b'-') || is_thematic_break(b'-'),
-        '_' => is_thematic_break(b'_'),
-        '*' => is_unordered_list_marker("* ") || is_thematic_break(b'*'),
-        '+' => is_unordered_list_marker("+ "),
-        '`' => is_fenced_code_block("```"),
-        '~' => is_fenced_code_block("~~~"),
-        '>' | ':' => true,
-        _ => false,
+        '#' if is_atx_heading() => Some(EscapeKind::SingleLine(SingleLineEscape::AtxHeader)),
+        '=' if is_setext_heading(b'=') => {
+            Some(EscapeKind::MultiLine(MultiLineEscape::SetextHeader))
+        }
+        '-' => {
+            if is_thematic_break(b'-') {
+                Some(EscapeKind::SingleLine(SingleLineEscape::ThematicBreak))
+            } else if is_unordered_list_marker("- ") {
+                Some(EscapeKind::SingleLine(SingleLineEscape::UnorderedList))
+            } else if is_setext_heading(b'-') {
+                Some(EscapeKind::MultiLine(MultiLineEscape::SetextHeader))
+            } else {
+                None
+            }
+        }
+        '_' if is_thematic_break(b'_') => {
+            Some(EscapeKind::SingleLine(SingleLineEscape::ThematicBreak))
+        }
+        '*' => {
+            if is_thematic_break(b'*') {
+                Some(EscapeKind::SingleLine(SingleLineEscape::ThematicBreak))
+            } else if is_unordered_list_marker("* ") {
+                Some(EscapeKind::SingleLine(SingleLineEscape::UnorderedList))
+            } else {
+                None
+            }
+        }
+        '+' if is_unordered_list_marker("+ ") => {
+            Some(EscapeKind::SingleLine(SingleLineEscape::UnorderedList))
+        }
+        '`' if is_fenced_code_block("```") => {
+            Some(EscapeKind::SingleLine(SingleLineEscape::FencedCodeBlock))
+        }
+        '~' if is_fenced_code_block("~~~") => {
+            Some(EscapeKind::SingleLine(SingleLineEscape::FencedCodeBlock))
+        }
+        '>' => Some(EscapeKind::SingleLine(SingleLineEscape::BlockQuote)),
+        _ => None,
     }
+}
+
+/// Represents text that looks like another Markdown construct that the formatter should escape
+/// in order to preserve the meaning of the input after formatting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EscapeKind {
+    /// The formatter can be sure that this text needs to be escaped.
+    SingleLine(SingleLineEscape),
+    /// Context about preceding lines is required in order to know for sure that this text
+    /// should be escaped
+    MultiLine(MultiLineEscape),
+}
+
+/// Escapes for Markdown constructs that are defined on a single line
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SingleLineEscape {
+    /// Escape text that looks like an atx header `# `, `#`, `## `, `##`, ... `###### `, `######`.
+    AtxHeader,
+    /// Escape text that looks like a blockquote `>`.
+    BlockQuote,
+    /// Escape text that looks like an unordered list.
+    /// ```markdown
+    /// *
+    /// -
+    /// +
+    /// ```
+    UnorderedList,
+    /// Escape text that looks like a thematic break. The text might contain whitespace.
+    /// ```markdown
+    /// ***
+    /// * * *
+    /// ___
+    /// _ _ _
+    /// ---
+    /// - - -
+    /// ```
+    ThematicBreak,
+    /// Escape ``` or ~~~ that might look like a fenced code block.
+    FencedCodeBlock,
+}
+
+/// Escapes for Markdown constructs that are defined over multiple lines.
+///
+/// These escapes need context about surrounding lines in order to know for sure that they should
+/// be applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MultiLineEscape {
+    /// Escape text that looks like a setext headers
+    /// ```markdown
+    /// h1
+    /// =
+    ///
+    /// h2
+    /// -
+    /// ```
+    SetextHeader,
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -466,7 +466,7 @@ where
             let trailing_space_count = count_trailing_spaces(line);
             let trailing_spaces = get_spaces(trailing_space_count);
 
-            let needs_escape = self.needs_escape(line, true);
+            let needs_escape = self.needs_escape(line, true).is_some();
 
             let line = line.trim_end();
 
@@ -629,7 +629,7 @@ where
                         self.needs_indent = false;
                     }
 
-                    let needs_escape = self.needs_escape(text, false);
+                    let needs_escape = self.needs_escape(text, false).is_some();
 
                     let could_be_interpreted_as_html =
                         |t: &str, state: &mut FormatState<'i, 'm, I>| -> bool {

--- a/src/paragraph.rs
+++ b/src/paragraph.rs
@@ -88,7 +88,7 @@ impl WriteContext<'_> for Paragraph {
             self.buffer.push('\\');
         }
 
-        let needs_escape = needs_escape(s);
+        let needs_escape = needs_escape(s).is_some();
 
         // Prevent the next pass from ignoring the hard break or misinterpreting `s`
         // as something other than text in a paragraph


### PR DESCRIPTION
The `EscapKind` enum gives more context to the caller about what kind of text the formatter thinks it's trying to escape. For now, I'm just calling `.is_some()` in order to not mess with the current formatting behavior, but the idea it to eventually start matching on the `EscapeKind` to implement more context aware escaping.