### PR TITLE
updated thematic break and list marker escaping

### DIFF
--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -100,6 +100,12 @@ TT
 [\ ]:]
 
 
+<!-- Don't need to escape the double **. It won't be interpreted as a list -->
+
+**
+:
+
+
 <!-- escape what looks like rule -->
 [.]:a
     ***

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -100,6 +100,12 @@
 [\\]: ]
 
 
+<!-- Don't need to escape the double **. It won't be interpreted as a list -->
+
+**
+:
+
+
 <!-- escape what looks like rule -->
 [.]: a
 \***


### PR DESCRIPTION
Reuse the atx_heading logic for list markers since they're both very similar, and update the thematic break escaping to be more accurate. Previously the formatter considered `**` a thematic break, but at least three `***` are needed to define a thematic break.