### PR TITLE
Add extra context to `EscapeKind` about which marker was found

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -119,7 +119,7 @@ impl TryFrom<char> for OrderedListMarker {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(super) enum UnorderedListMarker {
     Asterisk,
     Plus,


### PR DESCRIPTION
I think this will help when we need to escape multiple characters so that the formatter knows exactly which characters need to be escaped.