### PR TITLE
fix: update code fence escaping logic

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -70,7 +70,25 @@ pub(crate) fn needs_escape(input: &str) -> Option<EscapeKind> {
         input.bytes().all(|b| b == value || b == b' ')
             && input.bytes().filter(|b| *b == value).count() >= 3
     };
-    let is_fenced_code_block = |value: &str| input.starts_with(value);
+    let is_fenced_code_block = |value: &str| {
+        let marker = value
+            .chars()
+            .next()
+            .expect("value hast at least one character");
+
+        if !input.starts_with(value) {
+            return false;
+        }
+
+        let info_string = input.trim_start_matches(marker).trim_start();
+
+        if info_string.is_empty() {
+            return true;
+        }
+
+        // opening code fences can't contain backtick (`) or tilde (~) in the info string.
+        !info_string.contains(['`', '~'])
+    };
 
     match first_char {
         '#' if is_atx_heading() => Some(EscapeKind::SingleLine(SingleLineEscape::AtxHeader)),

--- a/tests/source/escaping.md
+++ b/tests/source/escaping.md
@@ -322,6 +322,16 @@ F
 G  
     #######
 
+<!-- Don't need to escape because "```@``" can't be a code fence because backticks aren't allowed in the info string -->
+
+`
+```@`` 
+`
+
+<!-- We don't need to worry about escaping when the code is on a single line -->
+` ```@``  `
+
+
 <!-- multi-line-code escape -->
 
 > `start of code

--- a/tests/target/escaping.md
+++ b/tests/target/escaping.md
@@ -322,6 +322,16 @@ F
 G  
 #######
 
+<!-- Don't need to escape because "```@``" can't be a code fence because backticks aren't allowed in the info string -->
+
+`
+```@`` 
+`
+
+<!-- We don't need to worry about escaping when the code is on a single line -->
+` ```@``  `
+
+
 <!-- multi-line-code escape -->
 
 > `start of code


### PR DESCRIPTION
Now text that looks like a code fence wont be escaped if backticks or tildes exist in what would be the `info string`.