### PR TITLE
fix: allow (strong) emphasis and strikethough to start a paragraph

### DIFF
--- a/src/adapters/loose_list.rs
+++ b/src/adapters/loose_list.rs
@@ -128,7 +128,13 @@ where
             | Event::FootnoteReference(_)
             | Event::TaskListMarker(_)
             | Event::InlineHtml(_)
-            | Event::Start(Tag::Link { .. } | Tag::Image { .. }) => true,
+            | Event::Start(
+                Tag::Link { .. }
+                | Tag::Image { .. }
+                | Tag::Emphasis
+                | Tag::Strong
+                | Tag::Strikethrough,
+            ) => true,
             Event::Html(text) => is_single_html_tag(text),
             _ => false,
         }

--- a/src/adapters/test/loose_list/emphasis_strong_emphasis_strikethrough.md
+++ b/src/adapters/test/loose_list/emphasis_strong_emphasis_strikethrough.md
@@ -1,0 +1,97 @@
+*
+  *A*
+  A
+
+
++
+  _B_
+  B
+
+
+-
+  **C**
+  C
+
+
+*
+  __D__
+  D
+
+
++
+  ~E~
+  E
+
+
+-
+  ~~F~~
+  F
+
+==========
+
+event=Start(List(None)) range=0..14
+event=Start(Item) range=0..14
+event=Start(Paragraph) range=4..11
+event=Start(Emphasis) range=4..7
+event=Text(Borrowed("A")) range=5..6
+event=End(Emphasis) range=4..7
+event=SoftBreak range=7..8
+event=Text(Borrowed("A")) range=10..11
+event=End(Paragraph) range=4..11
+event=End(Item) range=0..14
+event=End(List(false)) range=0..14
+event=Start(List(None)) range=14..28
+event=Start(Item) range=14..28
+event=Start(Paragraph) range=18..25
+event=Start(Emphasis) range=18..21
+event=Text(Borrowed("B")) range=19..20
+event=End(Emphasis) range=18..21
+event=SoftBreak range=21..22
+event=Text(Borrowed("B")) range=24..25
+event=End(Paragraph) range=18..25
+event=End(Item) range=14..28
+event=End(List(false)) range=14..28
+event=Start(List(None)) range=28..44
+event=Start(Item) range=28..44
+event=Start(Paragraph) range=32..41
+event=Start(Strong) range=32..37
+event=Text(Borrowed("C")) range=34..35
+event=End(Strong) range=32..37
+event=SoftBreak range=37..38
+event=Text(Borrowed("C")) range=40..41
+event=End(Paragraph) range=32..41
+event=End(Item) range=28..44
+event=End(List(false)) range=28..44
+event=Start(List(None)) range=44..60
+event=Start(Item) range=44..60
+event=Start(Paragraph) range=48..57
+event=Start(Strong) range=48..53
+event=Text(Borrowed("D")) range=50..51
+event=End(Strong) range=48..53
+event=SoftBreak range=53..54
+event=Text(Borrowed("D")) range=56..57
+event=End(Paragraph) range=48..57
+event=End(Item) range=44..60
+event=End(List(false)) range=44..60
+event=Start(List(None)) range=60..74
+event=Start(Item) range=60..74
+event=Start(Paragraph) range=64..71
+event=Start(Strikethrough) range=64..67
+event=Text(Borrowed("E")) range=65..66
+event=End(Strikethrough) range=64..67
+event=SoftBreak range=67..68
+event=Text(Borrowed("E")) range=70..71
+event=End(Paragraph) range=64..71
+event=End(Item) range=60..74
+event=End(List(false)) range=60..74
+event=Start(List(None)) range=74..89
+event=Start(Item) range=74..89
+event=Start(Paragraph) range=78..87
+event=Start(Strikethrough) range=78..83
+event=Text(Borrowed("F")) range=80..81
+event=End(Strikethrough) range=78..83
+event=SoftBreak range=83..84
+event=Text(Borrowed("F")) range=86..87
+event=End(Paragraph) range=78..87
+event=End(Item) range=74..89
+event=End(List(false)) range=74..89

--- a/tests/source/empty_lists.md
+++ b/tests/source/empty_lists.md
@@ -108,3 +108,94 @@
 <!-- Tight list that starts with a hard break should be idempotent -->
 * \
 ~
+
+<!-- list with emphasis -->
+*
+  *A*
+A
+
+
++
+  _B_
+B
+
+
+-
+  *C*
+C
+
+
+*
+  _D_
+D
+
+
++
+  *E*
+E
+
+
+-
+  _F_
+F
+
+<!-- list with strong emphasis -->
+
+*
+  **G**
+G
+
+
++
+  __H__
+H
+
+
+-
+  **I**
+I
+
+
+*
+  __J__
+J
+
+
++
+  **K**
+K
+
+
+-
+  __L__
+L
+
+<!-- list with strikethrough -->
+*
+  ~M~
+M
+
+
++
+  ~~N~~
+N
+
+
+-
+  ~~O~~
+O
+
+
+*
+  ~~P~~
+P
+
+
++
+  ~~Q~~
+Q
+
+
+-
+  ~~R~~
+R

--- a/tests/target/empty_lists.md
+++ b/tests/target/empty_lists.md
@@ -110,3 +110,94 @@
 <!-- Tight list that starts with a hard break should be idempotent -->
 * \
   ~
+
+<!-- list with emphasis -->
+*
+  *A*
+  A
+
+
++
+  _B_
+  B
+
+
+-
+  *C*
+  C
+
+
+*
+  _D_
+  D
+
+
++
+  *E*
+  E
+
+
+-
+  _F_
+  F
+
+<!-- list with strong emphasis -->
+
+*
+  **G**
+  G
+
+
++
+  __H__
+  H
+
+
+-
+  **I**
+  I
+
+
+*
+  __J__
+  J
+
+
++
+  **K**
+  K
+
+
+-
+  __L__
+  L
+
+<!-- list with strikethrough -->
+*
+  ~M~
+  M
+
+
++
+  ~~N~~
+  N
+
+
+-
+  ~~O~~
+  O
+
+
+*
+  ~~P~~
+  P
+
+
++
+  ~~Q~~
+  Q
+
+
+-
+  ~~R~~
+  R


### PR DESCRIPTION
Now the loose list adapter recognizes emphasis, strong emphasis, and strikethough as the start of a paragraph.